### PR TITLE
feat(falcon): Variant A — /falcon-a full PrimeVue UI

### DIFF
--- a/frontend/components/falcon-a/DataInspectorPanel.vue
+++ b/frontend/components/falcon-a/DataInspectorPanel.vue
@@ -1,5 +1,52 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [DataInspectorPanel — stub; implemented in a later task]
-  </div>
+  <Dialog
+    v-model:visible="visible"
+    header="Selection Details"
+    :modal="false"
+    :dismissable-mask="true"
+    :style="{ width: '380px' }"
+    position="bottomright"
+    class="!z-50"
+  >
+    <div
+      class="font-mono text-sm leading-6 text-gray-800 dark:text-gray-200 mb-3 select-text"
+      v-html="html"
+    />
+    <Button
+      icon="pi pi-copy"
+      :label="copyLabel"
+      severity="secondary"
+      outlined
+      size="small"
+      class="w-full"
+      @click="copy"
+    />
+  </Dialog>
 </template>
+
+<script setup>
+import { ref } from 'vue';
+
+const visible = ref(false);
+const html = ref('');
+const copyLabel = ref('Copy to Clipboard');
+
+function show(rawHtml) {
+  html.value = rawHtml || 'No data available for this point.';
+  visible.value = true;
+}
+
+async function copy() {
+  const tmp = document.createElement('div');
+  tmp.innerHTML = html.value;
+  try {
+    await navigator.clipboard.writeText(tmp.innerText);
+    copyLabel.value = 'Copied!';
+    setTimeout(() => (copyLabel.value = 'Copy to Clipboard'), 1500);
+  } catch (err) {
+    console.error('clipboard write failed', err);
+  }
+}
+
+defineExpose({ show });
+</script>

--- a/frontend/components/falcon-a/DataInspectorPanel.vue
+++ b/frontend/components/falcon-a/DataInspectorPanel.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [DataInspectorPanel — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/components/falcon-a/DataTableTab.vue
+++ b/frontend/components/falcon-a/DataTableTab.vue
@@ -1,5 +1,112 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [DataTableTab — stub; implemented in a later task]
+  <div class="space-y-4">
+    <div class="flex items-center gap-3">
+      <SelectButton
+        v-model="currentDataset"
+        :options="datasetOptions"
+        option-label="label"
+        option-value="value"
+        :allow-empty="false"
+      />
+      <InputText
+        v-model="state.searchQuery"
+        placeholder="Search entire table..."
+        class="w-64"
+      />
+    </div>
+
+    <DataTable
+      :value="pageRows"
+      :lazy="true"
+      :paginator="true"
+      :rows="rowsPerPage"
+      :total-records="filteredCount"
+      :first="(state.currentPage - 1) * rowsPerPage"
+      @page="onPage"
+      @sort="onSort"
+      :sort-field="state.sortCol"
+      :sort-order="state.sortAsc ? 1 : -1"
+      striped-rows
+      scrollable
+      scroll-height="60vh"
+      class="p-datatable-sm"
+    >
+      <Column
+        v-for="col in columns"
+        :key="col"
+        :field="col"
+        :header="col"
+        sortable
+      />
+    </DataTable>
   </div>
 </template>
+
+<script setup>
+import { computed, ref, watch } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+import { FALCON_ROWS_PER_PAGE } from '~/utils/falcon/config';
+
+const store = useFalconStore();
+const rowsPerPage = FALCON_ROWS_PER_PAGE;
+
+const datasetOptions = [
+  { value: 'genes', label: 'Genes' },
+  { value: 'variants', label: 'Variants' },
+];
+const currentDataset = ref('genes');
+const state = computed(() => store.tableStates[currentDataset.value]);
+
+const columns = computed(() => store.datasets[currentDataset.value].columns);
+
+const filteredAndSorted = computed(() => {
+  const raw = store.datasets[currentDataset.value].data;
+  const q = state.value.searchQuery?.toLowerCase();
+  let rows = raw;
+  if (q) {
+    rows = rows.filter((r) =>
+      columns.value.some((c) =>
+        String(r[c] ?? '')
+          .toLowerCase()
+          .includes(q),
+      ),
+    );
+  }
+  const { sortCol, sortAsc } = state.value;
+  if (sortCol) {
+    rows = [...rows].sort((a, b) => {
+      const av = a[sortCol],
+        bv = b[sortCol];
+      const an = parseFloat(av),
+        bn = parseFloat(bv);
+      const num = !isNaN(an) && !isNaN(bn);
+      const cmp = num
+        ? an - bn
+        : String(av ?? '').localeCompare(String(bv ?? ''));
+      return sortAsc ? cmp : -cmp;
+    });
+  }
+  return rows;
+});
+
+const filteredCount = computed(() => filteredAndSorted.value.length);
+
+const pageRows = computed(() => {
+  const start = (state.value.currentPage - 1) * rowsPerPage;
+  return filteredAndSorted.value.slice(start, start + rowsPerPage);
+});
+
+function onPage(evt) {
+  state.value.currentPage = evt.first / rowsPerPage + 1;
+}
+
+function onSort(evt) {
+  state.value.sortCol = evt.sortField;
+  state.value.sortAsc = evt.sortOrder === 1;
+}
+
+// Reset page when dataset or query changes
+watch([currentDataset, () => state.value.searchQuery], () => {
+  state.value.currentPage = 1;
+});
+</script>

--- a/frontend/components/falcon-a/DataTableTab.vue
+++ b/frontend/components/falcon-a/DataTableTab.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [DataTableTab — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/components/falcon-a/ExecutiveSummaryTab.vue
+++ b/frontend/components/falcon-a/ExecutiveSummaryTab.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [ExecutiveSummaryTab — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/components/falcon-a/ExecutiveSummaryTab.vue
+++ b/frontend/components/falcon-a/ExecutiveSummaryTab.vue
@@ -1,5 +1,147 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [ExecutiveSummaryTab — stub; implemented in a later task]
+  <div class="space-y-6">
+    <div class="flex items-center gap-3">
+      <Button
+        icon="pi pi-database"
+        :label="
+          clinicalTrials.isLoaded
+            ? 'Clinical Trials Loaded'
+            : 'Load Clinical Trials CSV'
+        "
+        :severity="clinicalTrials.isLoaded ? 'success' : 'primary'"
+        @click="triggerTrialsUpload"
+      />
+      <Button
+        :icon="showNovel ? 'pi pi-star-fill' : 'pi pi-star'"
+        :label="showNovel ? 'Novelty filter: ON' : 'Novelty filter: OFF'"
+        severity="secondary"
+        outlined
+        @click="toggleNovelty"
+      />
+      <input
+        ref="trialsInput"
+        type="file"
+        accept=".csv"
+        class="hidden"
+        @change="onTrialsFile"
+      />
+    </div>
+
+    <section>
+      <h3 class="text-lg font-semibold mb-2">Top Genes per Clump</h3>
+      <TraitCard
+        v-for="row in filteredGenesTop"
+        :key="`g-top-${row.index}`"
+        :row="row"
+      />
+    </section>
+
+    <section>
+      <h3 class="text-lg font-semibold mb-2">Lead Genes per Chromosome</h3>
+      <TraitCard
+        v-for="row in filteredGenesLead"
+        :key="`g-lead-${row.index}`"
+        :row="row"
+      />
+    </section>
+
+    <section>
+      <h3 class="text-lg font-semibold mb-2">Top Variants per Clump</h3>
+      <TraitCard
+        v-for="row in summary.variants?.top || []"
+        :key="`v-top-${row.index}`"
+        :row="row"
+      />
+    </section>
+
+    <section>
+      <h3 class="text-lg font-semibold mb-2">Lead Variants per Chromosome</h3>
+      <TraitCard
+        v-for="row in summary.variants?.lead || []"
+        :key="`v-lead-${row.index}`"
+        :row="row"
+      />
+    </section>
   </div>
 </template>
+
+<script setup>
+import { computed, ref, watch } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+import { useFalconSummary } from '~/composables/useFalconSummary';
+
+const store = useFalconStore();
+const { computeTopAndLeadSignals, attachClinicalTrials, attachNoveltyFlags } =
+  useFalconSummary(store);
+
+const clinicalTrials = store.clinicalTrials;
+const summary = ref({
+  genes: { top: [], lead: [] },
+  variants: { top: [], lead: [] },
+});
+const showNovel = ref(false);
+let abortCtrl = null;
+
+watch(
+  () => [
+    store.datasets.genes.isLoaded,
+    store.datasets.variants.isLoaded,
+    clinicalTrials.isLoaded,
+  ],
+  recompute,
+  { immediate: true },
+);
+
+function recompute() {
+  const s = computeTopAndLeadSignals();
+  ['top', 'lead'].forEach((k) => {
+    attachClinicalTrials(s.genes[k]);
+    attachClinicalTrials(s.variants[k]);
+  });
+  summary.value = s;
+}
+
+const filteredGenesTop = computed(() =>
+  showNovel.value
+    ? (summary.value.genes?.top || []).filter((r) => r.isNovel === true)
+    : summary.value.genes?.top || [],
+);
+
+const filteredGenesLead = computed(() =>
+  showNovel.value
+    ? (summary.value.genes?.lead || []).filter((r) => r.isNovel === true)
+    : summary.value.genes?.lead || [],
+);
+
+async function toggleNovelty() {
+  showNovel.value = !showNovel.value;
+  if (showNovel.value) {
+    if (abortCtrl) abortCtrl.abort();
+    abortCtrl = new AbortController();
+    const all = [
+      ...summary.value.genes.top,
+      ...summary.value.genes.lead,
+    ];
+    try {
+      await attachNoveltyFlags(all, abortCtrl.signal);
+    } catch (err) {
+      if (err.name !== 'AbortError') console.error(err);
+    }
+  }
+}
+
+const trialsInput = ref(null);
+function triggerTrialsUpload() {
+  trialsInput.value?.click();
+}
+async function onTrialsFile(e) {
+  const f = e.target.files?.[0];
+  if (!f) return;
+  try {
+    await store.loadClinicalTrialsCsv(f);
+    recompute();
+  } catch (err) {
+    console.error('clinical trials load failed', err);
+  }
+}
+</script>

--- a/frontend/components/falcon-a/FolderPicker.vue
+++ b/frontend/components/falcon-a/FolderPicker.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [FolderPicker — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/components/falcon-a/FolderPicker.vue
+++ b/frontend/components/falcon-a/FolderPicker.vue
@@ -1,5 +1,43 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [FolderPicker — stub; implemented in a later task]
+  <div class="flex items-center gap-3">
+    <Button
+      icon="pi pi-folder-open"
+      label="Choose Folder"
+      severity="secondary"
+      outlined
+      @click="triggerFileDialog"
+    />
+    <span
+      v-if="selectedFileCount > 0"
+      class="text-xs text-gray-500 dark:text-gray-400"
+    >
+      {{ selectedFileCount }} file(s) selected
+    </span>
+    <input
+      ref="fileInput"
+      type="file"
+      webkitdirectory
+      directory
+      class="hidden"
+      @change="onChange"
+    />
   </div>
 </template>
+
+<script setup>
+import { ref } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+
+const store = useFalconStore();
+const fileInput = ref(null);
+const selectedFileCount = ref(0);
+
+function triggerFileDialog() {
+  fileInput.value?.click();
+}
+
+async function onChange(e) {
+  selectedFileCount.value = e.target.files?.length || 0;
+  await store.loadFolder(e.target.files);
+}
+</script>

--- a/frontend/components/falcon-a/GenesScatterTab.vue
+++ b/frontend/components/falcon-a/GenesScatterTab.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [GenesScatterTab — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/components/falcon-a/GenesScatterTab.vue
+++ b/frontend/components/falcon-a/GenesScatterTab.vue
@@ -1,5 +1,47 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [GenesScatterTab — stub; implemented in a later task]
+  <div class="space-y-4">
+    <GenomicRegionFilter />
+    <div
+      class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded p-2"
+    >
+      <div ref="plotEl" class="w-full" style="height: 600px" />
+    </div>
   </div>
 </template>
+
+<script setup>
+import { ref, watchEffect, onBeforeUnmount, inject } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+import { useFalconPlots } from '~/composables/useFalconPlots';
+import { usePlotly } from '~/composables/usePlotly';
+
+const store = useFalconStore();
+const { buildGenesScatterSpec } = useFalconPlots(store);
+const { mount, unmount, getPlotly } = usePlotly();
+const inspector = inject('falcon-inspector', null);
+const plotEl = ref(null);
+
+let current = null;
+let clickHandler = null;
+
+watchEffect(async () => {
+  const spec = buildGenesScatterSpec();
+  if (!plotEl.value) return;
+  await mount(plotEl.value, spec);
+  current = plotEl.value;
+
+  await getPlotly();
+  if (clickHandler) current.removeAllListeners?.('plotly_click');
+  clickHandler = (ev) => {
+    if (!ev?.points?.length || !inspector?.value) return;
+    const p = ev.points[0];
+    const txt = p.text || p.hovertext || 'No data available.';
+    inspector.value.show(txt);
+  };
+  current.on('plotly_click', clickHandler);
+});
+
+onBeforeUnmount(async () => {
+  if (current) await unmount(current);
+});
+</script>

--- a/frontend/components/falcon-a/GenomicRegionFilter.vue
+++ b/frontend/components/falcon-a/GenomicRegionFilter.vue
@@ -1,0 +1,153 @@
+<template>
+  <Card>
+    <template #content>
+      <Fieldset legend="Genomic Region Filter" :toggleable="true">
+        <div class="flex items-center gap-2 mb-3">
+          <Button
+            v-if="selectedChr !== 'All'"
+            icon="pi pi-refresh"
+            label="Reset to All Chromosomes"
+            severity="danger"
+            outlined
+            size="small"
+            @click="reset"
+          />
+        </div>
+
+        <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
+          Select a chromosome:
+        </p>
+        <SelectButton
+          v-model="selectedChr"
+          :options="chrOptions"
+          option-label="label"
+          option-value="value"
+          :allow-empty="false"
+          class="mb-4 flex-wrap"
+        />
+
+        <div v-if="selectedChr !== 'All' && currentBounds" class="space-y-2">
+          <p class="text-xs text-gray-500 dark:text-gray-400">
+            Select base-pair range:
+          </p>
+          <Slider
+            v-model="bpRange"
+            range
+            :min="currentBounds.min"
+            :max="currentBounds.max"
+            :step="bpStep"
+            class="mx-2"
+            @change="applyRange"
+          />
+          <div class="flex items-end gap-3">
+            <div class="flex flex-col gap-1">
+              <label
+                class="text-xs font-semibold text-gray-600 dark:text-gray-300"
+                >Start BP</label
+              >
+              <InputNumber
+                v-model="bpRange[0]"
+                :min="currentBounds.min"
+                :max="bpRange[1]"
+                :use-grouping="true"
+                class="w-40"
+                @blur="applyRange"
+              />
+            </div>
+            <div class="flex flex-col gap-1">
+              <label
+                class="text-xs font-semibold text-gray-600 dark:text-gray-300"
+                >End BP</label
+              >
+              <InputNumber
+                v-model="bpRange[1]"
+                :min="bpRange[0]"
+                :max="currentBounds.max"
+                :use-grouping="true"
+                class="w-40"
+                @blur="applyRange"
+              />
+            </div>
+          </div>
+        </div>
+      </Fieldset>
+    </template>
+  </Card>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+
+const store = useFalconStore();
+
+// Derive per-chromosome bounds from the loaded genes dataset.
+const chrBounds = computed(() => {
+  const bounds = new Map();
+  for (const row of store.datasets.genes.data) {
+    const chr = row.CHR ? String(row.CHR).trim() : '';
+    if (!chr) continue;
+    const s = parseFloat(row.START);
+    const e = parseFloat(row.END);
+    if (isNaN(s) && isNaN(e)) continue;
+    const b = bounds.get(chr) || { min: Infinity, max: -Infinity };
+    if (!isNaN(s)) b.min = Math.min(b.min, s);
+    if (!isNaN(e)) b.max = Math.max(b.max, e);
+    bounds.set(chr, b);
+  }
+  return bounds;
+});
+
+const chrOptions = computed(() => {
+  const chrs = Array.from(chrBounds.value.keys()).sort((a, b) => {
+    const na = parseInt(a, 10);
+    const nb = parseInt(b, 10);
+    if (!isNaN(na) && !isNaN(nb)) return na - nb;
+    return a.localeCompare(b);
+  });
+  return [
+    { value: 'All', label: 'All' },
+    ...chrs.map((c) => ({ value: c, label: c })),
+  ];
+});
+
+const selectedChr = ref(store.plotFilters.genes.chr || 'All');
+const currentBounds = computed(() =>
+  selectedChr.value === 'All' ? null : chrBounds.value.get(selectedChr.value),
+);
+
+const bpRange = ref([0, 0]);
+const bpStep = computed(() => {
+  if (!currentBounds.value) return 1;
+  const span = currentBounds.value.max - currentBounds.value.min;
+  return Math.max(1, Math.round(span / 1000)); // ~1000-step slider resolution
+});
+
+watch(
+  currentBounds,
+  (b) => {
+    if (!b) return;
+    bpRange.value = [b.min, b.max];
+    applyRange();
+  },
+  { immediate: true },
+);
+
+watch(selectedChr, (chr) => {
+  store.plotFilters.genes.chr = chr;
+  if (chr === 'All') {
+    store.plotFilters.genes.minStart = null;
+    store.plotFilters.genes.maxEnd = null;
+  }
+});
+
+function applyRange() {
+  if (!currentBounds.value) return;
+  store.plotFilters.genes.minStart = bpRange.value[0];
+  store.plotFilters.genes.maxEnd = bpRange.value[1];
+}
+
+function reset() {
+  selectedChr.value = 'All';
+}
+</script>

--- a/frontend/components/falcon-a/GlobalFilterBar.vue
+++ b/frontend/components/falcon-a/GlobalFilterBar.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [GlobalFilterBar — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/components/falcon-a/GlobalFilterBar.vue
+++ b/frontend/components/falcon-a/GlobalFilterBar.vue
@@ -1,5 +1,59 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [GlobalFilterBar — stub; implemented in a later task]
-  </div>
+  <Card>
+    <template #content>
+      <Fieldset legend="Global Filters" :toggleable="false" class="!p-0">
+        <div class="flex flex-wrap items-center gap-4 py-1">
+          <ToggleButton
+            v-model="store.globalFilter.active"
+            on-label="Strict Filter: ON"
+            off-label="Strict Filter: OFF"
+            on-icon="pi pi-filter"
+            off-icon="pi pi-filter-slash"
+          />
+          <div class="flex items-center gap-2">
+            <label
+              for="gf-min-prob"
+              class="text-xs font-semibold text-gray-600 dark:text-gray-300"
+              >Min Prob</label
+            >
+            <InputNumber
+              id="gf-min-prob"
+              v-model="store.globalFilter.minProb"
+              :min="0"
+              :max="1"
+              :step="0.01"
+              :min-fraction-digits="2"
+              :max-fraction-digits="4"
+              show-buttons
+              button-layout="horizontal"
+              class="w-40"
+            />
+          </div>
+          <div class="flex items-center gap-2">
+            <label
+              for="gf-min-negp"
+              class="text-xs font-semibold text-gray-600 dark:text-gray-300"
+              >Min NegP</label
+            >
+            <InputNumber
+              id="gf-min-negp"
+              v-model="store.globalFilter.minNegP"
+              :min="0"
+              :step="0.5"
+              :min-fraction-digits="1"
+              :max-fraction-digits="2"
+              show-buttons
+              button-layout="horizontal"
+              class="w-40"
+            />
+          </div>
+        </div>
+      </Fieldset>
+    </template>
+  </Card>
 </template>
+
+<script setup>
+import { useFalconStore } from '~/stores/FalconStore';
+const store = useFalconStore();
+</script>

--- a/frontend/components/falcon-a/LogSummaryTab.vue
+++ b/frontend/components/falcon-a/LogSummaryTab.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [LogSummaryTab — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/components/falcon-a/LogSummaryTab.vue
+++ b/frontend/components/falcon-a/LogSummaryTab.vue
@@ -1,5 +1,164 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [LogSummaryTab — stub; implemented in a later task]
+  <div class="space-y-4">
+    <div class="flex items-center justify-between flex-wrap gap-3">
+      <h3 class="text-xl font-semibold">FALCON Execution Time Summary</h3>
+      <Tag
+        severity="success"
+        :value="`Total Execution Time: ${totalTime}`"
+        class="text-base"
+      />
+    </div>
+
+    <Card>
+      <template #title>About this summary</template>
+      <template #content>
+        <p class="text-sm text-gray-600 dark:text-gray-300 mb-2">
+          This section visualizes the execution time for various components of
+          the FALCON algorithm per iteration. If a component was skipped during
+          an iteration for optimization (e.g., "Lazy link activated"), the
+          sample is ignored on the analysis, and <b>n</b> on the top of each
+          plot shows the number of times the step was actually performed.
+        </p>
+        <p
+          class="text-sm text-gray-600 dark:text-gray-300 border-l-4 border-primary-500 pl-3 py-2 bg-gray-50 dark:bg-gray-800"
+        >
+          <b>⏱️ Parallel Wall Time Calculation:</b> Because FALCON processes
+          chromosomes concurrently and does not synchronize until
+          <em>each chromosome finishes all of its pre-process steps</em>, the
+          Whole Genome pre-process time is not the sum of individual step
+          maximums. Instead, it is calculated as the maximum total pre-process
+          time across all chromosomes (i.e., the slowest overall chromosome).
+          This accurately reflects the real-world elapsed time, as the pipeline
+          waits for the last chromosome to finish preparing before beginning
+          the synchronized Gibbs sampling.
+        </p>
+      </template>
+    </Card>
+
+    <div class="flex items-center gap-3">
+      <label class="text-sm font-semibold text-gray-700 dark:text-gray-200"
+        >Chromosome view:</label
+      >
+      <Select
+        v-model="chrView"
+        :options="chrOptions"
+        option-label="label"
+        option-value="value"
+        class="w-64"
+      />
+    </div>
+
+    <div ref="preprocessEl" class="w-full" style="height: 320px" />
+
+    <div
+      class="grid gap-4"
+      style="grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));"
+    >
+      <Card v-for="comp in components" :key="comp">
+        <template #title>{{ comp }}</template>
+        <template #content>
+          <div
+            class="flex flex-wrap gap-2 text-xs text-gray-500 dark:text-gray-400 mb-2 pb-2 border-b border-dashed border-gray-200 dark:border-gray-700"
+          >
+            <template v-if="compStats[comp]">
+              <Tag
+                severity="secondary"
+                :value="`Min: ${compStats[comp].min.toFixed(2)}s`"
+              />
+              <Tag
+                severity="secondary"
+                :value="`Med: ${compStats[comp].median.toFixed(2)}s`"
+              />
+              <Tag
+                severity="secondary"
+                :value="`Mean: ${compStats[comp].mean.toFixed(2)}s`"
+              />
+              <Tag
+                severity="secondary"
+                :value="`Max: ${compStats[comp].max.toFixed(2)}s`"
+              />
+              <span class="text-gray-400">n={{ compStats[comp].n }}</span>
+            </template>
+            <span v-else class="text-red-500 font-semibold">
+              No data recorded (component entirely skipped).
+            </span>
+          </div>
+          <div
+            :ref="(el) => (histRefs[comp] = el)"
+            class="w-full"
+            style="height: 240px"
+          />
+        </template>
+      </Card>
+    </div>
   </div>
 </template>
+
+<script setup>
+import { computed, ref, watchEffect, onBeforeUnmount } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+import { useFalconPlots } from '~/composables/useFalconPlots';
+import { useFalconLogParser } from '~/composables/useFalconLogParser';
+import { usePlotly } from '~/composables/usePlotly';
+
+const store = useFalconStore();
+const { buildLogIterHistogramSpec, buildLogPreprocessBarSpec } =
+  useFalconPlots(store);
+const { ITER_COMPONENTS: components } = useFalconLogParser();
+const { mount, unmount } = usePlotly();
+
+const chrView = ref('all');
+const chrOptions = computed(() => {
+  const chrs = Array.from(store.datasets.log.chromosomes).sort((a, b) => {
+    const na = parseInt(a, 10),
+      nb = parseInt(b, 10);
+    if (!isNaN(na) && !isNaN(nb)) return na - nb;
+    return a.localeCompare(b);
+  });
+  return [
+    { value: 'all', label: 'Whole Genome (Aggregate)' },
+    ...chrs.map((c) => ({ value: c, label: `Chromosome ${c}` })),
+  ];
+});
+
+const totalTime = computed(() => store.datasets.log.totalTime);
+
+const preprocessEl = ref(null);
+const histRefs = ref({});
+const mounted = new Set();
+
+const specs = computed(() => {
+  const out = {};
+  for (const c of components)
+    out[c] = buildLogIterHistogramSpec(c, chrView.value);
+  return out;
+});
+
+const compStats = computed(() => {
+  const out = {};
+  for (const c of components) out[c] = specs.value[c].stats;
+  return out;
+});
+
+watchEffect(async () => {
+  if (preprocessEl.value) {
+    await mount(preprocessEl.value, buildLogPreprocessBarSpec());
+    mounted.add(preprocessEl.value);
+  }
+  for (const comp of components) {
+    const el = histRefs.value[comp];
+    if (!el) continue;
+    const s = specs.value[comp];
+    if (!s.stats) {
+      el.innerHTML = '';
+      continue;
+    }
+    await mount(el, { data: s.data, layout: s.layout });
+    mounted.add(el);
+  }
+});
+
+onBeforeUnmount(async () => {
+  for (const el of mounted) await unmount(el);
+});
+</script>

--- a/frontend/components/falcon-a/TDPTab.vue
+++ b/frontend/components/falcon-a/TDPTab.vue
@@ -1,5 +1,185 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [TDPTab — stub; implemented in a later task]
+  <div class="space-y-4">
+    <Card>
+      <template #title>FALCON Zoom & LD Correlation</template>
+      <template #content>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+          Global filters apply at the moment you click Run Analysis — reload
+          the plot after changing them.
+        </p>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-semibold">Target Gene</label>
+            <InputText v-model="cfg.gene" placeholder="e.g., CETP" />
+          </div>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-semibold">Boundary (BP)</label>
+            <InputNumber
+              v-model="cfg.boundary"
+              :min="1000"
+              :step="50000"
+              :use-grouping="true"
+            />
+          </div>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-semibold">Focus</label>
+            <Select
+              v-model="cfg.focus"
+              :options="focusOptions"
+              option-label="label"
+              option-value="value"
+            />
+          </div>
+          <div class="flex flex-col gap-1">
+            <label class="text-xs font-semibold">Plot Type</label>
+            <Select
+              v-model="cfg.plotType"
+              :options="plotTypeOptions"
+              option-label="label"
+              option-value="value"
+            />
+          </div>
+        </div>
+
+        <Card class="mt-4 !bg-blue-50 dark:!bg-blue-950/40">
+          <template #title>LD Matrix</template>
+          <template #content>
+            <div class="flex flex-wrap items-end gap-3">
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-semibold"
+                  >LD Folder (.gz / .sorted)</label
+                >
+                <div class="flex items-center gap-2">
+                  <Button
+                    icon="pi pi-folder-open"
+                    :label="store.tdp.ldFolderName || 'Load LD Folder'"
+                    severity="secondary"
+                    outlined
+                    @click="triggerLdDialog"
+                  />
+                  <input
+                    ref="ldInput"
+                    type="file"
+                    webkitdirectory
+                    directory
+                    class="hidden"
+                    @change="onLdChange"
+                  />
+                </div>
+              </div>
+              <div class="flex flex-col gap-1">
+                <label class="text-xs font-semibold">Min R²</label>
+                <InputNumber
+                  v-model="cfg.minR2"
+                  :min="0"
+                  :max="1"
+                  :step="0.1"
+                  :min-fraction-digits="1"
+                  :max-fraction-digits="2"
+                  class="w-28"
+                />
+              </div>
+              <div class="flex flex-col gap-1 min-w-[160px]">
+                <label class="text-xs font-semibold"
+                  >Max Stretch: {{ cfg.maxStretch.toFixed(2) }}</label
+                >
+                <Slider
+                  v-model="cfg.maxStretch"
+                  :min="0.1"
+                  :max="1"
+                  :step="0.05"
+                />
+              </div>
+            </div>
+          </template>
+        </Card>
+
+        <div class="flex items-center justify-between mt-4">
+          <p
+            v-if="store.tdp.status"
+            class="text-sm text-primary-600 dark:text-primary-400 font-semibold"
+          >
+            {{ store.tdp.status }}
+          </p>
+          <span v-else></span>
+          <Button
+            icon="pi pi-play"
+            label="Run Analysis"
+            severity="primary"
+            :loading="running"
+            :disabled="running || !cfg.gene"
+            @click="run"
+          />
+        </div>
+      </template>
+    </Card>
+
+    <div
+      class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded p-2"
+    >
+      <div ref="plotEl" class="w-full" style="height: 850px" />
+    </div>
   </div>
 </template>
+
+<script setup>
+import { ref, reactive, onBeforeUnmount } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+import { useFalconTDP } from '~/composables/useFalconTDP';
+import { usePlotly } from '~/composables/usePlotly';
+
+const store = useFalconStore();
+const { runAnalysis } = useFalconTDP(store);
+const { mount, unmount } = usePlotly();
+
+const cfg = reactive({
+  gene: 'CETP',
+  boundary: 500000,
+  focus: 'region',
+  plotType: 'falcon',
+  minR2: 0.0,
+  maxStretch: 1.0,
+});
+
+const focusOptions = [
+  { value: 'region', label: 'Region' },
+  { value: 'gene', label: 'Gene Only' },
+];
+const plotTypeOptions = [
+  { value: 'falcon', label: 'FALCON' },
+  { value: 'raw', label: 'Raw input' },
+  { value: 'overlay', label: 'Overlay' },
+];
+
+const plotEl = ref(null);
+const ldInput = ref(null);
+const running = ref(false);
+let mountedEl = null;
+
+async function run() {
+  running.value = true;
+  try {
+    const spec = await runAnalysis({ ...cfg });
+    if (!spec || !plotEl.value) return;
+    await mount(plotEl.value, spec);
+    mountedEl = plotEl.value;
+  } catch (err) {
+    console.error('TDP runAnalysis failed:', err);
+    store.tdp.status = `Error: ${err.message || String(err)}`;
+  } finally {
+    running.value = false;
+  }
+}
+
+function triggerLdDialog() {
+  ldInput.value?.click();
+}
+async function onLdChange(e) {
+  await store.loadLdFolder(e.target.files);
+}
+
+onBeforeUnmount(async () => {
+  if (mountedEl) await unmount(mountedEl);
+});
+</script>

--- a/frontend/components/falcon-a/TDPTab.vue
+++ b/frontend/components/falcon-a/TDPTab.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [TDPTab — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/components/falcon-a/TraitCard.vue
+++ b/frontend/components/falcon-a/TraitCard.vue
@@ -1,0 +1,60 @@
+<template>
+  <Panel :toggleable="true" :collapsed="collapsed" class="mb-2">
+    <template #header>
+      <div class="flex items-center gap-3 w-full">
+        <span class="font-semibold text-gray-900 dark:text-gray-100">{{
+          row.name
+        }}</span>
+        <Tag :value="`Clump ${row.clumpId}`" severity="info" />
+        <Tag v-if="row.isLead" value="⭐ Lead" severity="warning" />
+        <Tag v-if="row.isNovel === false" value="Known" severity="secondary" />
+        <Tag v-if="row.isNovel === true" value="Novel" severity="success" />
+        <span class="text-xs text-gray-500 dark:text-gray-400 ml-auto">
+          Chr {{ row.chr }} · Prob {{ row.prob.toFixed(3) }} · NegP
+          {{ row.negP.toFixed(2) }}
+        </span>
+      </div>
+    </template>
+
+    <div v-if="row.traits?.length" class="mb-3">
+      <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-1">
+        Associated traits
+      </h4>
+      <ul class="text-xs space-y-1 list-disc list-inside">
+        <li v-for="(t, i) in row.traits" :key="i">
+          <span class="font-mono">{{ t.Trait || t.trait || '—' }}</span>
+          <span v-if="t.Citation || t.citation" class="text-gray-500">
+            ({{ t.Citation || t.citation }})
+          </span>
+        </li>
+      </ul>
+    </div>
+
+    <div v-if="row.clinicalTrials?.length">
+      <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-1">
+        Clinical trials
+      </h4>
+      <ul class="text-xs space-y-1">
+        <li v-for="(t, i) in row.clinicalTrials" :key="i">
+          <span class="font-mono">{{ t.drugId }}</span>
+          · {{ t.indication }} ·
+          <Tag :value="`Phase ${t.phase}`" severity="info" class="ml-1" />
+        </li>
+      </ul>
+    </div>
+
+    <div
+      v-if="!row.traits?.length && !row.clinicalTrials?.length"
+      class="text-xs text-gray-500 dark:text-gray-400"
+    >
+      No trait or trial data.
+    </div>
+  </Panel>
+</template>
+
+<script setup>
+defineProps({
+  row: { type: Object, required: true },
+  collapsed: { type: Boolean, default: true },
+});
+</script>

--- a/frontend/components/falcon-a/VariantsScatterTab.vue
+++ b/frontend/components/falcon-a/VariantsScatterTab.vue
@@ -1,5 +1,46 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [VariantsScatterTab — stub; implemented in a later task]
+  <div class="space-y-4">
+    <div
+      class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded p-2"
+    >
+      <div ref="plotEl" class="w-full" style="height: 600px" />
+    </div>
   </div>
 </template>
+
+<script setup>
+import { ref, watchEffect, onBeforeUnmount, inject } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+import { useFalconPlots } from '~/composables/useFalconPlots';
+import { usePlotly } from '~/composables/usePlotly';
+
+const store = useFalconStore();
+const { buildVariantsScatterSpec } = useFalconPlots(store);
+const { mount, unmount, getPlotly } = usePlotly();
+const inspector = inject('falcon-inspector', null);
+const plotEl = ref(null);
+
+let current = null;
+let clickHandler = null;
+
+watchEffect(async () => {
+  const spec = buildVariantsScatterSpec();
+  if (!plotEl.value) return;
+  await mount(plotEl.value, spec);
+  current = plotEl.value;
+
+  await getPlotly();
+  if (clickHandler) current.removeAllListeners?.('plotly_click');
+  clickHandler = (ev) => {
+    if (!ev?.points?.length || !inspector?.value) return;
+    const p = ev.points[0];
+    const txt = p.text || p.hovertext || 'No data available.';
+    inspector.value.show(txt);
+  };
+  current.on('plotly_click', clickHandler);
+});
+
+onBeforeUnmount(async () => {
+  if (current) await unmount(current);
+});
+</script>

--- a/frontend/components/falcon-a/VariantsScatterTab.vue
+++ b/frontend/components/falcon-a/VariantsScatterTab.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [VariantsScatterTab — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/pages/falcon-a/index.vue
+++ b/frontend/pages/falcon-a/index.vue
@@ -40,31 +40,31 @@
       </TabList>
 
       <TabPanels>
-        <TabPanel value="summary">
+        <TabPanel value="summary" :lazy="true">
           <ExecutiveSummaryTab v-if="store.datasets.genes.isLoaded" />
           <EmptyTab v-else reason="Load a folder to see the executive summary." />
         </TabPanel>
 
-        <TabPanel value="tdp">
+        <TabPanel value="tdp" :lazy="true">
           <TDPTab />
         </TabPanel>
 
-        <TabPanel value="genes">
+        <TabPanel value="genes" :lazy="true">
           <GenesScatterTab v-if="store.datasets.genes.isLoaded" />
           <EmptyTab v-else reason="Load a folder containing .wg.genes." />
         </TabPanel>
 
-        <TabPanel value="variants">
+        <TabPanel value="variants" :lazy="true">
           <VariantsScatterTab v-if="store.datasets.variants.isLoaded" />
           <EmptyTab v-else reason="Load a folder containing .wg.variants." />
         </TabPanel>
 
-        <TabPanel value="table">
+        <TabPanel value="table" :lazy="true">
           <DataTableTab v-if="store.datasets.genes.isLoaded" />
           <EmptyTab v-else reason="Load a folder to browse the raw tables." />
         </TabPanel>
 
-        <TabPanel value="log">
+        <TabPanel value="log" :lazy="true">
           <LogSummaryTab v-if="store.datasets.log.isLoaded" />
           <EmptyTab v-else reason="Load a folder containing .wg.log." />
         </TabPanel>

--- a/frontend/pages/falcon-a/index.vue
+++ b/frontend/pages/falcon-a/index.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 w-full py-6 space-y-4">
+    <div class="flex items-center justify-between gap-3">
+      <div>
+        <h1 class="text-2xl font-bold">FALCON Dashboard</h1>
+        <p class="text-sm text-gray-600 dark:text-gray-400">
+          Variant A — full PrimeVue
+        </p>
+      </div>
+      <Tag
+        v-if="store.folderName"
+        severity="success"
+        :value="`Active Dataset: ${store.folderName}`"
+      />
+    </div>
+
+    <FolderPicker />
+    <GlobalFilterBar />
+
+    <p v-if="store.status" class="text-sm text-gray-500">{{ store.status }}</p>
+
+    <Tabs :value="activeTab" @update:value="onTabChange">
+      <TabList>
+        <Tab value="summary" :disabled="!store.datasets.genes.isLoaded">
+          Executive Summary
+        </Tab>
+        <Tab value="tdp">FALCON Zoom</Tab>
+        <Tab value="genes" :disabled="!store.datasets.genes.isLoaded">
+          Genes Plot
+        </Tab>
+        <Tab value="variants" :disabled="!store.datasets.variants.isLoaded">
+          Variants Plot
+        </Tab>
+        <Tab value="table" :disabled="!store.datasets.genes.isLoaded">
+          Data Table
+        </Tab>
+        <Tab value="log" :disabled="!store.datasets.log.isLoaded">
+          Execution Time
+        </Tab>
+      </TabList>
+
+      <TabPanels>
+        <TabPanel value="summary">
+          <ExecutiveSummaryTab v-if="store.datasets.genes.isLoaded" />
+          <EmptyTab v-else reason="Load a folder to see the executive summary." />
+        </TabPanel>
+
+        <TabPanel value="tdp">
+          <TDPTab />
+        </TabPanel>
+
+        <TabPanel value="genes">
+          <GenesScatterTab v-if="store.datasets.genes.isLoaded" />
+          <EmptyTab v-else reason="Load a folder containing .wg.genes." />
+        </TabPanel>
+
+        <TabPanel value="variants">
+          <VariantsScatterTab v-if="store.datasets.variants.isLoaded" />
+          <EmptyTab v-else reason="Load a folder containing .wg.variants." />
+        </TabPanel>
+
+        <TabPanel value="table">
+          <DataTableTab v-if="store.datasets.genes.isLoaded" />
+          <EmptyTab v-else reason="Load a folder to browse the raw tables." />
+        </TabPanel>
+
+        <TabPanel value="log">
+          <LogSummaryTab v-if="store.datasets.log.isLoaded" />
+          <EmptyTab v-else reason="Load a folder containing .wg.log." />
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+
+    <DataInspectorPanel ref="inspectorRef" />
+  </div>
+</template>
+
+<script setup>
+import { h, ref, provide, watch } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+
+const store = useFalconStore();
+const route = useRoute();
+const router = useRouter();
+const activeTab = ref(route.query.tab || 'summary');
+const inspectorRef = ref(null);
+provide('falcon-inspector', inspectorRef);
+
+// Local helper — muted empty-state message for tabs until their dataset loads.
+const EmptyTab = (props) =>
+  h(
+    'p',
+    { class: 'text-sm text-gray-500 dark:text-gray-400 py-6' },
+    props.reason || 'No data yet.',
+  );
+EmptyTab.props = ['reason'];
+
+function onTabChange(next) {
+  if (!next || next === activeTab.value) return;
+  activeTab.value = next;
+  router.push({ query: { ...route.query, tab: next } });
+}
+
+watch(
+  () => route.query.tab,
+  (next) => {
+    if (next && next !== activeTab.value) activeTab.value = next;
+  },
+);
+</script>


### PR DESCRIPTION
## Summary

Adds **Variant A** of the FALCON Results Viewer at `/falcon-a` — a full-PrimeVue treatment for side-by-side pilot comparison against Variant B (`/falcon-b`, separate PR).

Builds on `falcon-port-base` (#29). Touches **only** `frontend/pages/falcon-a/` and `frontend/components/falcon-a/`. Zero edits to shared `stores/`, `composables/`, or `utils/`. No conflict with the Variant B PR.

Six-tab dashboard:
- **Executive Summary** — PrimeVue Panel-collapsible TraitCards × four sections (top/lead × genes/variants), clinical-trials CSV upload, novelty filter with cancelable codetabs fetch
- **FALCON Zoom** — PrimeVue Card with InputText/InputNumber/Select/Slider controls
- **Genes Plot** — Plotly scatter + PrimeVue SelectButton chromosome filter + Slider :range BP filter
- **Variants Plot** — Plotly scatter, no region filter
- **Data Table** — PrimeVue DataTable with lazy paginator, sortable Columns, search input, SelectButton dataset switcher
- **Execution Time** — PrimeVue Card grid with Tag-based stats + Plotly histograms

Plus shared chrome:
- PrimeVue `Tabs` strip with URL-synced active tab (`?tab=...`)
- `Tag` pill for active dataset
- `ToggleButton` + `InputNumber` × 2 in `Card` > `Fieldset` for global filters
- `Dialog` (position bottomright) for the floating data-inspector panel
- Dark mode works on every surface

Implementation plan at `docs/superpowers/plans/2026-04-24-falcon-variant-a.md` (10 tasks, ~1,178 LOC).

## Test plan

- [ ] Visit `/falcon-a` logged out → redirects to `/login`
- [ ] Logged in: chrome renders (title, subtitle "Variant A — full PrimeVue", PrimeVue Choose Folder Button, Global Filters Card+Fieldset, Tabs strip with disabled states based on dataset presence)
- [ ] Load a folder → tabs unlock, active-dataset Tag appears
- [ ] Each tab renders without console errors
- [ ] Click a Plotly point on Genes Plot → DataInspectorPanel Dialog appears bottom-right
- [ ] Toggle Strict Filter → scatter rebuilds
- [ ] Switch chromosome in GenomicRegionFilter → scatter rescopes
- [ ] Sort/paginate/search the Data Table; switch genes ↔ variants
- [ ] Load `clinical_trials.csv` → Tags appear on TraitCards
- [ ] Run TDP analysis with default `CETP` (no LD folder) → trait-only plot renders
- [ ] Toggle dark mode → every tab readable
- [ ] Reload a different dataset → cache reset works (verified via base PR)

## Dependencies

This PR currently includes the commits from `falcon-port-base` (#29). After that PR merges to `main`, this PR's diff will auto-shrink to just the Variant A files. Reviewers can focus on `pages/falcon-a/**` and `components/falcon-a/**`.

## Perf note

PrimeVue Tabs is non-lazy by default. `:lazy="true"` was added to each `<TabPanel>` so unvisited tabs don't render their content. Summary still renders ~4500 Panel components on first visit if it's the active tab; pagination/virtualization is a v2 candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)