### PR TITLE
feat(falcon): Variant B — /falcon-b PrimeVue shell, custom guts

### DIFF
--- a/frontend/components/falcon-b/DataInspectorPanel.vue
+++ b/frontend/components/falcon-b/DataInspectorPanel.vue
@@ -1,5 +1,103 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [DataInspectorPanel — stub; implemented in a later task]
+  <div v-show="visible" class="falcon-inspector">
+    <div class="falcon-inspector-header">
+      <h4>🔍 Selection Details</h4>
+      <button class="falcon-inspector-close" @click="visible = false">&times;</button>
+    </div>
+    <div class="falcon-inspector-body">
+      <div class="falcon-inspector-content" v-html="html" />
+      <button class="falcon-inspector-copy" @click="copy">
+        📋 {{ copyLabel }}
+      </button>
+    </div>
   </div>
 </template>
+
+<script setup>
+import { ref } from 'vue';
+
+const visible = ref(false);
+const html = ref('');
+const copyLabel = ref('Copy to Clipboard');
+
+function show(rawHtml) {
+  html.value = rawHtml || 'No data available for this point.';
+  visible.value = true;
+}
+
+async function copy() {
+  const tmp = document.createElement('div');
+  tmp.innerHTML = html.value;
+  try {
+    await navigator.clipboard.writeText(tmp.innerText);
+    copyLabel.value = 'Copied!';
+    setTimeout(() => (copyLabel.value = 'Copy to Clipboard'), 1500);
+  } catch (err) {
+    console.error('clipboard write failed', err);
+  }
+}
+
+defineExpose({ show });
+</script>
+
+<style scoped>
+/* From PEGS index.html:214-226 */
+.falcon-inspector {
+  position: fixed;
+  bottom: 30px;
+  right: 30px;
+  width: 320px;
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+  z-index: 9999;
+  overflow: hidden;
+  color: #111827;
+}
+.falcon-inspector-header {
+  padding: 12px 15px;
+  background: #f3f4f6;
+  border-bottom: 1px solid #d1d5db;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.falcon-inspector-header h4 {
+  margin: 0;
+  color: #111827;
+  font-size: 1em;
+}
+.falcon-inspector-close {
+  background: none;
+  border: none;
+  font-size: 1.2em;
+  color: #6b7280;
+  cursor: pointer;
+}
+.falcon-inspector-body {
+  padding: 15px;
+}
+.falcon-inspector-content {
+  font-family: monospace;
+  font-size: 0.95em;
+  line-height: 1.6;
+  color: #374151;
+  margin-bottom: 15px;
+  user-select: text;
+}
+.falcon-inspector-copy {
+  width: 100%;
+  padding: 8px;
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+  color: #374151;
+  transition: background 0.2s;
+}
+.falcon-inspector-copy:hover {
+  background: #f3f4f6;
+}
+</style>

--- a/frontend/components/falcon-b/DataInspectorPanel.vue
+++ b/frontend/components/falcon-b/DataInspectorPanel.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [DataInspectorPanel — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/components/falcon-b/DataTableTab.vue
+++ b/frontend/components/falcon-b/DataTableTab.vue
@@ -1,5 +1,218 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [DataTableTab — stub; implemented in a later task]
+  <div>
+    <div class="toolbar">
+      <div class="inner-switch">
+        <button
+          v-for="opt in datasetOptions"
+          :key="opt.value"
+          :class="{ active: currentDataset === opt.value }"
+          @click="currentDataset = opt.value"
+        >
+          {{ opt.label }}
+        </button>
+      </div>
+      <input
+        v-model="state.searchQuery"
+        type="text"
+        placeholder="Search entire table..."
+        class="search-input"
+      />
+    </div>
+
+    <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th
+              v-for="col in columns"
+              :key="col"
+              @click="handleSort(col)"
+            >
+              {{ col }}
+              <span v-if="state.sortCol === col" class="sort-arrow">
+                {{ state.sortAsc ? '▲' : '▼' }}
+              </span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(row, i) in pageRows" :key="i">
+            <td v-for="col in columns" :key="col">{{ row[col] }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="pagination">
+      <button
+        class="page-btn"
+        :disabled="state.currentPage <= 1"
+        @click="state.currentPage--"
+      >
+        Previous
+      </button>
+      <span>Page {{ state.currentPage }} of {{ totalPages }}</span>
+      <button
+        class="page-btn"
+        :disabled="state.currentPage >= totalPages"
+        @click="state.currentPage++"
+      >
+        Next
+      </button>
+    </div>
   </div>
 </template>
+
+<script setup>
+import { computed, ref, watch } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+import { FALCON_ROWS_PER_PAGE } from '~/utils/falcon/config';
+
+const store = useFalconStore();
+const rowsPerPage = FALCON_ROWS_PER_PAGE;
+
+const datasetOptions = [
+  { value: 'genes', label: 'Genes' },
+  { value: 'variants', label: 'Variants' },
+];
+const currentDataset = ref('genes');
+const state = computed(() => store.tableStates[currentDataset.value]);
+const columns = computed(() => store.datasets[currentDataset.value].columns);
+
+const filteredAndSorted = computed(() => {
+  const raw = store.datasets[currentDataset.value].data;
+  const q = state.value.searchQuery?.toLowerCase();
+  let rows = raw;
+  if (q) {
+    rows = rows.filter((r) =>
+      columns.value.some((c) =>
+        String(r[c] ?? '').toLowerCase().includes(q),
+      ),
+    );
+  }
+  const { sortCol, sortAsc } = state.value;
+  if (sortCol) {
+    rows = [...rows].sort((a, b) => {
+      const av = a[sortCol], bv = b[sortCol];
+      const an = parseFloat(av), bn = parseFloat(bv);
+      const num = !isNaN(an) && !isNaN(bn);
+      const cmp = num
+        ? an - bn
+        : String(av ?? '').localeCompare(String(bv ?? ''));
+      return sortAsc ? cmp : -cmp;
+    });
+  }
+  return rows;
+});
+
+const totalPages = computed(() =>
+  Math.max(1, Math.ceil(filteredAndSorted.value.length / rowsPerPage)),
+);
+
+const pageRows = computed(() => {
+  const start = (state.value.currentPage - 1) * rowsPerPage;
+  return filteredAndSorted.value.slice(start, start + rowsPerPage);
+});
+
+function handleSort(col) {
+  if (state.value.sortCol === col) {
+    state.value.sortAsc = !state.value.sortAsc;
+  } else {
+    state.value.sortCol = col;
+    state.value.sortAsc = true;
+  }
+  state.value.currentPage = 1;
+}
+
+watch([currentDataset, () => state.value.searchQuery], () => {
+  state.value.currentPage = 1;
+});
+</script>
+
+<style scoped>
+.toolbar {
+  display: flex;
+  gap: 15px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-bottom: 15px;
+}
+.inner-switch {
+  display: flex;
+  gap: 4px;
+}
+.inner-switch button {
+  padding: 6px 14px;
+  border: 1px solid #d1d5db;
+  background: white;
+  cursor: pointer;
+  border-radius: 4px;
+  font-weight: 500;
+  color: #4b5563;
+  transition: 0.2s;
+}
+.inner-switch button.active {
+  background: #3b82f6;
+  color: white;
+  border-color: #3b82f6;
+}
+.search-input {
+  padding: 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  width: 250px;
+  font-size: 0.9em;
+}
+.table-wrapper {
+  overflow: auto;
+  max-height: 60vh;
+  border: 1px solid #d1d5db;
+  margin-bottom: 15px;
+  background: white;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+th, td {
+  padding: 10px;
+  text-align: left;
+  border-bottom: 1px solid #e5e7eb;
+  white-space: nowrap;
+  font-size: 0.9em;
+}
+th {
+  background-color: #f3f4f6;
+  cursor: pointer;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+th:hover {
+  background-color: #e5e7eb;
+}
+.sort-arrow {
+  margin-left: 4px;
+  color: #3b82f6;
+}
+.pagination {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: flex-end;
+}
+.page-btn {
+  padding: 6px 12px;
+  border: 1px solid #d1d5db;
+  background: white;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.page-btn:hover:not(:disabled) {
+  background: #f3f4f6;
+}
+.page-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/frontend/components/falcon-b/DataTableTab.vue
+++ b/frontend/components/falcon-b/DataTableTab.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [DataTableTab — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/components/falcon-b/ExecutiveSummaryTab.vue
+++ b/frontend/components/falcon-b/ExecutiveSummaryTab.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [ExecutiveSummaryTab — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/components/falcon-b/ExecutiveSummaryTab.vue
+++ b/frontend/components/falcon-b/ExecutiveSummaryTab.vue
@@ -1,5 +1,151 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [ExecutiveSummaryTab — stub; implemented in a later task]
+  <div>
+    <div class="summary-toolbar">
+      <button
+        class="summary-btn"
+        :class="{ primary: !clinicalTrials.isLoaded, success: clinicalTrials.isLoaded }"
+        @click="triggerTrialsUpload"
+      >
+        {{ clinicalTrials.isLoaded ? '✓ Clinical Trials Loaded' : 'Load Clinical Trials CSV' }}
+      </button>
+      <button class="summary-btn outline" @click="toggleNovelty">
+        {{ showNovel ? 'Novelty filter: ON' : 'Novelty filter: OFF' }}
+      </button>
+      <input
+        ref="trialsInput"
+        type="file"
+        accept=".csv"
+        class="hidden"
+        @change="onTrialsFile"
+      />
+    </div>
+
+    <section class="summary-section">
+      <h3>Top Genes per Clump</h3>
+      <TraitCard v-for="row in filteredGenesTop" :key="`g-top-${row.index}`" :row="row" />
+    </section>
+    <section class="summary-section">
+      <h3>Lead Genes per Chromosome</h3>
+      <TraitCard v-for="row in filteredGenesLead" :key="`g-lead-${row.index}`" :row="row" />
+    </section>
+    <section class="summary-section">
+      <h3>Top Variants per Clump</h3>
+      <TraitCard v-for="row in summary.variants?.top || []" :key="`v-top-${row.index}`" :row="row" />
+    </section>
+    <section class="summary-section">
+      <h3>Lead Variants per Chromosome</h3>
+      <TraitCard v-for="row in summary.variants?.lead || []" :key="`v-lead-${row.index}`" :row="row" />
+    </section>
   </div>
 </template>
+
+<script setup>
+import { computed, ref, watch } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+import { useFalconSummary } from '~/composables/useFalconSummary';
+
+const store = useFalconStore();
+const { computeTopAndLeadSignals, attachClinicalTrials, attachNoveltyFlags } =
+  useFalconSummary(store);
+
+const clinicalTrials = store.clinicalTrials;
+const summary = ref({
+  genes: { top: [], lead: [] },
+  variants: { top: [], lead: [] },
+});
+const showNovel = ref(false);
+let abortCtrl = null;
+
+watch(
+  () => [
+    store.datasets.genes.isLoaded,
+    store.datasets.variants.isLoaded,
+    clinicalTrials.isLoaded,
+  ],
+  recompute,
+  { immediate: true },
+);
+
+function recompute() {
+  const s = computeTopAndLeadSignals();
+  ['top', 'lead'].forEach((k) => {
+    attachClinicalTrials(s.genes[k]);
+    attachClinicalTrials(s.variants[k]);
+  });
+  summary.value = s;
+}
+
+const filteredGenesTop = computed(() =>
+  showNovel.value
+    ? (summary.value.genes?.top || []).filter((r) => r.isNovel === true)
+    : summary.value.genes?.top || [],
+);
+const filteredGenesLead = computed(() =>
+  showNovel.value
+    ? (summary.value.genes?.lead || []).filter((r) => r.isNovel === true)
+    : summary.value.genes?.lead || [],
+);
+
+async function toggleNovelty() {
+  showNovel.value = !showNovel.value;
+  if (showNovel.value) {
+    if (abortCtrl) abortCtrl.abort();
+    abortCtrl = new AbortController();
+    const all = [...summary.value.genes.top, ...summary.value.genes.lead];
+    try {
+      await attachNoveltyFlags(all, abortCtrl.signal);
+    } catch (err) {
+      if (err.name !== 'AbortError') console.error(err);
+    }
+  }
+}
+
+const trialsInput = ref(null);
+function triggerTrialsUpload() { trialsInput.value?.click(); }
+async function onTrialsFile(e) {
+  const f = e.target.files?.[0];
+  if (!f) return;
+  try {
+    await store.loadClinicalTrialsCsv(f);
+    recompute();
+  } catch (err) {
+    console.error('clinical trials load failed', err);
+  }
+}
+</script>
+
+<style scoped>
+.summary-toolbar {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+.summary-btn {
+  padding: 8px 14px;
+  border-radius: 4px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid #d1d5db;
+  background: white;
+  color: #374151;
+  transition: 0.2s;
+}
+.summary-btn.primary { background: #3b82f6; color: white; border-color: #3b82f6; }
+.summary-btn.primary:hover { background: #2563eb; }
+.summary-btn.success { background: #d1fae5; color: #047857; border-color: #10b981; }
+.summary-btn.outline { background: white; }
+.summary-btn.outline:hover { background: #f3f4f6; }
+.summary-section {
+  margin-bottom: 28px;
+}
+.summary-section h3 {
+  font-size: 1.05em;
+  font-weight: 700;
+  color: #111827;
+  margin: 0 0 10px 0;
+  padding-bottom: 6px;
+  border-bottom: 2px solid #3b82f6;
+}
+.hidden { display: none; }
+</style>

--- a/frontend/components/falcon-b/FolderPicker.vue
+++ b/frontend/components/falcon-b/FolderPicker.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [FolderPicker — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/components/falcon-b/FolderPicker.vue
+++ b/frontend/components/falcon-b/FolderPicker.vue
@@ -1,5 +1,35 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [FolderPicker — stub; implemented in a later task]
+  <div class="flex items-center gap-3">
+    <input
+      ref="fileInput"
+      type="file"
+      webkitdirectory
+      directory
+      class="falcon-b-folder-input"
+      @change="onChange"
+    />
   </div>
 </template>
+
+<script setup>
+import { ref } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+
+const store = useFalconStore();
+const fileInput = ref(null);
+
+async function onChange(e) {
+  await store.loadFolder(e.target.files);
+}
+</script>
+
+<style scoped>
+/* From PEGS styles.css:20-22 — original input appearance */
+.falcon-b-folder-input {
+  padding: 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: white;
+  font-size: 0.9em;
+}
+</style>

--- a/frontend/components/falcon-b/GenesScatterTab.vue
+++ b/frontend/components/falcon-b/GenesScatterTab.vue
@@ -1,5 +1,54 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [GenesScatterTab — stub; implemented in a later task]
+  <div class="space-y-4">
+    <GenomicRegionFilter />
+    <div class="plot-wrapper">
+      <div ref="plotEl" class="w-full" style="height: 600px" />
+    </div>
   </div>
 </template>
+
+<script setup>
+import { ref, watchEffect, onBeforeUnmount, inject } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+import { useFalconPlots } from '~/composables/useFalconPlots';
+import { usePlotly } from '~/composables/usePlotly';
+
+const store = useFalconStore();
+const { buildGenesScatterSpec } = useFalconPlots(store);
+const { mount, unmount, getPlotly } = usePlotly();
+const inspector = inject('falcon-inspector', null);
+const plotEl = ref(null);
+
+let current = null;
+let clickHandler = null;
+
+watchEffect(async () => {
+  const spec = buildGenesScatterSpec();
+  if (!plotEl.value) return;
+  await mount(plotEl.value, spec);
+  current = plotEl.value;
+
+  await getPlotly();
+  if (clickHandler) current.removeAllListeners?.('plotly_click');
+  clickHandler = (ev) => {
+    if (!ev?.points?.length || !inspector?.value) return;
+    const p = ev.points[0];
+    const txt = p.text || p.hovertext || 'No data available.';
+    inspector.value.show(txt);
+  };
+  current.on('plotly_click', clickHandler);
+});
+
+onBeforeUnmount(async () => {
+  if (current) await unmount(current);
+});
+</script>
+
+<style scoped>
+.plot-wrapper {
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  padding: 8px;
+}
+</style>

--- a/frontend/components/falcon-b/GenesScatterTab.vue
+++ b/frontend/components/falcon-b/GenesScatterTab.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [GenesScatterTab — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/components/falcon-b/GenomicRegionFilter.vue
+++ b/frontend/components/falcon-b/GenomicRegionFilter.vue
@@ -1,0 +1,356 @@
+<template>
+  <div class="filter-card">
+    <div class="filter-header">
+      <h4><span style="font-size: 1.2em">🧬</span> Genomic Region Filter</h4>
+      <button
+        v-if="selectedChr !== 'All'"
+        class="reset-btn"
+        @click="reset"
+      >
+        Reset to All Chromosomes
+      </button>
+    </div>
+    <div class="filter-body">
+      <p class="filter-hint">Select a Chromosome:</p>
+      <div class="chr-grid">
+        <button
+          v-for="opt in chrOptions"
+          :key="opt.value"
+          class="chr-btn"
+          :class="{ active: selectedChr === opt.value }"
+          @click="selectedChr = opt.value"
+        >
+          {{ opt.label }}
+        </button>
+      </div>
+
+      <div
+        v-if="selectedChr !== 'All' && currentBounds"
+        class="region-selector"
+      >
+        <p class="filter-hint">Select Base Pair Range:</p>
+        <div class="range-slider">
+          <div class="slider-track" />
+          <div
+            class="slider-range"
+            :style="{
+              left: rangePercent(0) + '%',
+              width: rangeWidthPercent() + '%',
+            }"
+          />
+          <input
+            type="range"
+            :min="currentBounds.min"
+            :max="currentBounds.max"
+            :step="bpStep"
+            :value="bpRange[0]"
+            @input="onLowInput($event)"
+          />
+          <input
+            type="range"
+            :min="currentBounds.min"
+            :max="currentBounds.max"
+            :step="bpStep"
+            :value="bpRange[1]"
+            @input="onHighInput($event)"
+          />
+        </div>
+        <div class="region-inputs">
+          <div class="input-group">
+            <label>Start BP</label>
+            <input
+              type="number"
+              :min="currentBounds.min"
+              :max="bpRange[1]"
+              :value="bpRange[0]"
+              @blur="onStartBlur"
+            />
+          </div>
+          <div class="input-group">
+            <label>End BP</label>
+            <input
+              type="number"
+              :min="bpRange[0]"
+              :max="currentBounds.max"
+              :value="bpRange[1]"
+              @blur="onEndBlur"
+            />
+          </div>
+          <button class="apply-btn" @click="applyRange">Apply Range</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+
+const store = useFalconStore();
+
+const chrBounds = computed(() => {
+  const bounds = new Map();
+  for (const row of store.datasets.genes.data) {
+    const chr = row.CHR ? String(row.CHR).trim() : '';
+    if (!chr) continue;
+    const s = parseFloat(row.START);
+    const e = parseFloat(row.END);
+    if (isNaN(s) && isNaN(e)) continue;
+    const b = bounds.get(chr) || { min: Infinity, max: -Infinity };
+    if (!isNaN(s)) b.min = Math.min(b.min, s);
+    if (!isNaN(e)) b.max = Math.max(b.max, e);
+    bounds.set(chr, b);
+  }
+  return bounds;
+});
+
+const chrOptions = computed(() => {
+  const chrs = Array.from(chrBounds.value.keys()).sort((a, b) => {
+    const na = parseInt(a, 10);
+    const nb = parseInt(b, 10);
+    if (!isNaN(na) && !isNaN(nb)) return na - nb;
+    return a.localeCompare(b);
+  });
+  return [
+    { value: 'All', label: 'All' },
+    ...chrs.map((c) => ({ value: c, label: c })),
+  ];
+});
+
+const selectedChr = ref(store.plotFilters.genes.chr || 'All');
+const currentBounds = computed(() =>
+  selectedChr.value === 'All' ? null : chrBounds.value.get(selectedChr.value),
+);
+
+const bpRange = ref([0, 0]);
+const bpStep = computed(() => {
+  if (!currentBounds.value) return 1;
+  const span = currentBounds.value.max - currentBounds.value.min;
+  return Math.max(1, Math.round(span / 1000));
+});
+
+watch(
+  currentBounds,
+  (b) => {
+    if (!b) return;
+    bpRange.value = [b.min, b.max];
+    applyRange();
+  },
+  { immediate: true },
+);
+
+watch(selectedChr, (chr) => {
+  store.plotFilters.genes.chr = chr;
+  if (chr === 'All') {
+    store.plotFilters.genes.minStart = null;
+    store.plotFilters.genes.maxEnd = null;
+  }
+});
+
+function onLowInput(e) {
+  const v = Number(e.target.value);
+  bpRange.value = [Math.min(v, bpRange.value[1]), bpRange.value[1]];
+  applyRange();
+}
+function onHighInput(e) {
+  const v = Number(e.target.value);
+  bpRange.value = [bpRange.value[0], Math.max(v, bpRange.value[0])];
+  applyRange();
+}
+function onStartBlur(e) {
+  bpRange.value = [Number(e.target.value), bpRange.value[1]];
+  applyRange();
+}
+function onEndBlur(e) {
+  bpRange.value = [bpRange.value[0], Number(e.target.value)];
+  applyRange();
+}
+function rangePercent(idx) {
+  if (!currentBounds.value) return 0;
+  const { min, max } = currentBounds.value;
+  return ((bpRange.value[idx] - min) / (max - min)) * 100;
+}
+function rangeWidthPercent() {
+  return rangePercent(1) - rangePercent(0);
+}
+function applyRange() {
+  if (!currentBounds.value) return;
+  store.plotFilters.genes.minStart = bpRange.value[0];
+  store.plotFilters.genes.maxEnd = bpRange.value[1];
+}
+function reset() {
+  selectedChr.value = 'All';
+}
+</script>
+
+<style scoped>
+/* Lifted from PEGS styles.css:55-110 */
+.filter-card {
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  margin-bottom: 20px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+}
+.filter-header {
+  padding: 12px 20px;
+  background: #f9fafb;
+  border-bottom: 1px solid #d1d5db;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.filter-header h4 {
+  margin: 0;
+  color: #111827;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.filter-body {
+  padding: 20px;
+  transition: all 0.3s ease;
+}
+.filter-hint {
+  margin: 0 0 10px 0;
+  font-size: 0.9em;
+  color: #4b5563;
+}
+.reset-btn {
+  padding: 4px 10px;
+  font-size: 0.8em;
+  background: #fee2e2;
+  color: #b91c1c;
+  border: 1px solid #f87171;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: 0.2s;
+}
+.reset-btn:hover {
+  background: #fecaca;
+}
+.chr-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.chr-btn {
+  padding: 6px 12px;
+  border: 1px solid #d1d5db;
+  background: white;
+  border-radius: 20px;
+  cursor: pointer;
+  font-weight: 500;
+  color: #4b5563;
+  transition: all 0.2s ease;
+}
+.chr-btn:hover {
+  border-color: #3b82f6;
+  color: #3b82f6;
+}
+.chr-btn.active {
+  background: #3b82f6;
+  color: white;
+  border-color: #3b82f6;
+  box-shadow: 0 2px 4px rgba(59, 130, 246, 0.3);
+}
+.region-selector {
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px dashed #d1d5db;
+  animation: fadeInDown 0.4s ease forwards;
+}
+@keyframes fadeInDown {
+  from { opacity: 0; transform: translateY(-10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.range-slider {
+  position: relative;
+  width: 100%;
+  height: 40px;
+}
+.slider-track {
+  position: absolute;
+  width: 100%;
+  height: 6px;
+  background: #e5e7eb;
+  border-radius: 3px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+}
+.slider-range {
+  position: absolute;
+  height: 6px;
+  background: #3b82f6;
+  border-radius: 3px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+}
+.range-slider input[type='range'] {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  -webkit-appearance: none;
+  background: transparent;
+  pointer-events: none;
+  z-index: 3;
+  margin: 0;
+}
+.range-slider input[type='range']::-webkit-slider-thumb {
+  pointer-events: auto;
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: white;
+  border: 2px solid #3b82f6;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  cursor: grab;
+}
+.range-slider input[type='range']::-webkit-slider-thumb:active {
+  cursor: grabbing;
+  background: #3b82f6;
+}
+.region-inputs {
+  display: flex;
+  gap: 15px;
+  align-items: flex-end;
+  margin-top: 15px;
+}
+.input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+}
+.input-group label {
+  font-size: 0.8em;
+  font-weight: bold;
+  color: #4b5563;
+}
+.input-group input {
+  padding: 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-family: monospace;
+}
+.apply-btn {
+  padding: 8px 14px;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+  height: fit-content;
+}
+.apply-btn:hover {
+  background: #2563eb;
+}
+</style>

--- a/frontend/components/falcon-b/GlobalFilterBar.vue
+++ b/frontend/components/falcon-b/GlobalFilterBar.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [GlobalFilterBar — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/components/falcon-b/GlobalFilterBar.vue
+++ b/frontend/components/falcon-b/GlobalFilterBar.vue
@@ -1,5 +1,45 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [GlobalFilterBar — stub; implemented in a later task]
+  <div
+    class="flex flex-wrap items-center gap-4 py-2 px-3 border rounded bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700"
+  >
+    <ToggleButton
+      v-model="store.globalFilter.active"
+      on-label="Strict Filter: ON"
+      off-label="Strict Filter: OFF"
+      on-icon="pi pi-filter"
+      off-icon="pi pi-filter-slash"
+    />
+    <div class="flex items-center gap-2">
+      <label class="text-xs font-semibold text-gray-600 dark:text-gray-300">Min Prob</label>
+      <InputNumber
+        v-model="store.globalFilter.minProb"
+        :min="0"
+        :max="1"
+        :step="0.01"
+        :min-fraction-digits="2"
+        :max-fraction-digits="4"
+        show-buttons
+        button-layout="horizontal"
+        class="w-36"
+      />
+    </div>
+    <div class="flex items-center gap-2">
+      <label class="text-xs font-semibold text-gray-600 dark:text-gray-300">Min NegP</label>
+      <InputNumber
+        v-model="store.globalFilter.minNegP"
+        :min="0"
+        :step="0.5"
+        :min-fraction-digits="1"
+        :max-fraction-digits="2"
+        show-buttons
+        button-layout="horizontal"
+        class="w-36"
+      />
+    </div>
   </div>
 </template>
+
+<script setup>
+import { useFalconStore } from '~/stores/FalconStore';
+const store = useFalconStore();
+</script>

--- a/frontend/components/falcon-b/LogSummaryTab.vue
+++ b/frontend/components/falcon-b/LogSummaryTab.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [LogSummaryTab — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/components/falcon-b/LogSummaryTab.vue
+++ b/frontend/components/falcon-b/LogSummaryTab.vue
@@ -1,5 +1,229 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [LogSummaryTab — stub; implemented in a later task]
+  <div>
+    <div class="log-header">
+      <h3>FALCON Execution Time Summary</h3>
+      <span class="total-time-pill">Total Execution Time: {{ totalTime }}</span>
+    </div>
+
+    <div class="explain-card">
+      <h4>About this summary</h4>
+      <p>
+        This section visualizes the execution time for various components of
+        the FALCON algorithm per iteration. If a component was skipped during
+        an iteration for optimization (e.g., "Lazy link activated"), the
+        sample is ignored on the analysis, and <b>n</b> on the top of the
+        plot shows the number of times the step was actually performed.
+      </p>
+      <p class="explain-callout">
+        <b>⏱️ Parallel Wall Time Calculation:</b> Because FALCON processes
+        chromosomes concurrently and does not synchronize until
+        <em>each chromosome finishes all of its pre-process steps</em>, the
+        Whole Genome pre-process time is not the sum of individual step
+        maximums. Instead, it is calculated as the maximum total pre-process
+        time across all chromosomes (i.e., the slowest overall chromosome).
+        This accurately reflects the real-world elapsed time, as the pipeline
+        waits for the last chromosome to finish preparing before beginning
+        the synchronized Gibbs sampling.
+      </p>
+    </div>
+
+    <div class="chr-select-row">
+      <label for="chr-view">Select Chromosome View:</label>
+      <select id="chr-view" v-model="chrView">
+        <option
+          v-for="opt in chrOptions"
+          :key="opt.value"
+          :value="opt.value"
+        >
+          {{ opt.label }}
+        </option>
+      </select>
+    </div>
+
+    <div ref="preprocessEl" class="preprocess-bar" />
+
+    <div class="hist-grid">
+      <div v-for="comp in components" :key="comp" class="hist-card">
+        <h4>{{ comp }}</h4>
+        <div v-if="compStats[comp]" class="stats-row">
+          <span><b>Min:</b> {{ compStats[comp].min.toFixed(2) }}s</span>
+          <span><b>Med:</b> {{ compStats[comp].median.toFixed(2) }}s</span>
+          <span><b>Mean:</b> {{ compStats[comp].mean.toFixed(2) }}s</span>
+          <span><b>Max:</b> {{ compStats[comp].max.toFixed(2) }}s</span>
+          <span class="muted">(n={{ compStats[comp].n }})</span>
+        </div>
+        <span v-else class="no-data">No data recorded (component skipped).</span>
+        <div :ref="(el) => (histRefs[comp] = el)" class="hist-plot" />
+      </div>
+    </div>
   </div>
 </template>
+
+<script setup>
+import { computed, ref, watchEffect, onBeforeUnmount } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+import { useFalconPlots } from '~/composables/useFalconPlots';
+import { useFalconLogParser } from '~/composables/useFalconLogParser';
+import { usePlotly } from '~/composables/usePlotly';
+
+const store = useFalconStore();
+const { buildLogIterHistogramSpec, buildLogPreprocessBarSpec } =
+  useFalconPlots(store);
+const { ITER_COMPONENTS: components } = useFalconLogParser();
+const { mount, unmount } = usePlotly();
+
+const chrView = ref('all');
+const chrOptions = computed(() => {
+  const chrs = Array.from(store.datasets.log.chromosomes).sort((a, b) => {
+    const na = parseInt(a, 10), nb = parseInt(b, 10);
+    if (!isNaN(na) && !isNaN(nb)) return na - nb;
+    return a.localeCompare(b);
+  });
+  return [
+    { value: 'all', label: 'Whole Genome (Aggregate)' },
+    ...chrs.map((c) => ({ value: c, label: `Chromosome ${c}` })),
+  ];
+});
+
+const totalTime = computed(() => store.datasets.log.totalTime);
+const preprocessEl = ref(null);
+const histRefs = ref({});
+const mounted = new Set();
+
+const specs = computed(() => {
+  const out = {};
+  for (const c of components)
+    out[c] = buildLogIterHistogramSpec(c, chrView.value);
+  return out;
+});
+const compStats = computed(() => {
+  const out = {};
+  for (const c of components) out[c] = specs.value[c].stats;
+  return out;
+});
+
+watchEffect(async () => {
+  if (preprocessEl.value) {
+    await mount(preprocessEl.value, buildLogPreprocessBarSpec());
+    mounted.add(preprocessEl.value);
+  }
+  for (const comp of components) {
+    const el = histRefs.value[comp];
+    if (!el) continue;
+    const s = specs.value[comp];
+    if (!s.stats) {
+      el.innerHTML = '';
+      continue;
+    }
+    await mount(el, { data: s.data, layout: s.layout });
+    mounted.add(el);
+  }
+});
+
+onBeforeUnmount(async () => {
+  for (const el of mounted) await unmount(el);
+});
+</script>
+
+<style scoped>
+.log-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+.log-header h3 { margin: 0; color: #111827; }
+.total-time-pill {
+  font-size: 1.1em;
+  font-weight: bold;
+  color: #047857;
+  background: #d1fae5;
+  padding: 8px 12px;
+  border-radius: 4px;
+  border: 1px solid #10b981;
+}
+.explain-card {
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+.explain-card h4 { margin-top: 0; color: #111827; }
+.explain-card p {
+  font-size: 0.9em;
+  color: #4b5563;
+  line-height: 1.5;
+  margin-bottom: 10px;
+}
+.explain-callout {
+  padding: 10px;
+  border-left: 3px solid #3b82f6;
+  background: #f9fafb;
+  margin: 0;
+}
+.chr-select-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+.chr-select-row label {
+  font-weight: bold;
+  color: #4b5563;
+}
+.chr-select-row select {
+  padding: 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: white;
+  min-width: 220px;
+}
+.preprocess-bar {
+  width: 100%;
+  height: 320px;
+  margin-bottom: 20px;
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+}
+.hist-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: 20px;
+}
+.hist-card {
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 15px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+.hist-card h4 { margin: 0 0 8px 0; color: #111827; }
+.stats-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: 0.85em;
+  color: #4b5563;
+  padding-bottom: 10px;
+  margin-bottom: 10px;
+  border-bottom: 1px dashed #e5e7eb;
+}
+.stats-row .muted { color: #9ca3af; font-size: 0.9em; }
+.no-data {
+  color: #ef4444;
+  font-weight: bold;
+  display: block;
+  padding-bottom: 10px;
+  margin-bottom: 10px;
+  border-bottom: 1px dashed #e5e7eb;
+}
+.hist-plot {
+  width: 100%;
+  height: 240px;
+}
+</style>

--- a/frontend/components/falcon-b/TDPTab.vue
+++ b/frontend/components/falcon-b/TDPTab.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [TDPTab — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/components/falcon-b/TDPTab.vue
+++ b/frontend/components/falcon-b/TDPTab.vue
@@ -1,5 +1,240 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [TDPTab — stub; implemented in a later task]
+  <div>
+    <h3 class="tdp-title">FALCON Zoom & LD Correlation</h3>
+    <p class="tdp-hint">
+      To apply the global filters the plot needs to be reloaded.
+    </p>
+
+    <div class="tdp-toolbar">
+      <div class="input-group">
+        <label>Target Gene</label>
+        <input v-model="cfg.gene" type="text" placeholder="e.g., CETP" />
+      </div>
+      <div class="input-group">
+        <label>Boundary (BP)</label>
+        <input v-model.number="cfg.boundary" type="number" step="50000" />
+      </div>
+      <div class="input-group">
+        <label>Focus</label>
+        <select v-model="cfg.focus">
+          <option value="region">Region</option>
+          <option value="gene">Gene Only</option>
+        </select>
+      </div>
+      <div class="input-group">
+        <label>Plot Type</label>
+        <select v-model="cfg.plotType">
+          <option value="falcon">FALCON</option>
+          <option value="raw">Raw input</option>
+          <option value="overlay">Overlay</option>
+        </select>
+      </div>
+
+      <div class="toolbar-divider" />
+
+      <div class="input-group">
+        <label class="ld-label">LD Matrix (.gz or .sorted files)</label>
+        <div class="ld-row">
+          <button class="ld-btn" @click="triggerLdDialog">
+            📁 {{ store.tdp.ldFolderName || 'Load LD Folder' }}
+          </button>
+          <input
+            ref="ldInput"
+            type="file"
+            webkitdirectory
+            directory
+            class="hidden"
+            @change="onLdChange"
+          />
+          <span class="divider-v" />
+          <label>Min R²</label>
+          <input
+            v-model.number="cfg.minR2"
+            type="number"
+            min="0"
+            max="1"
+            step="0.1"
+            class="mini-input"
+          />
+          <span class="divider-v" />
+          <label>Max Stretch</label>
+          <input
+            v-model.number="cfg.maxStretch"
+            type="range"
+            min="0.1"
+            max="1"
+            step="0.05"
+            class="stretch-range"
+          />
+        </div>
+      </div>
+
+      <div class="toolbar-spacer" />
+      <button
+        class="run-btn"
+        :disabled="running || !cfg.gene"
+        @click="run"
+      >
+        {{ running ? 'Running…' : 'Run Analysis' }}
+      </button>
+    </div>
+
+    <div v-if="store.tdp.status" class="tdp-status">
+      {{ store.tdp.status }}
+    </div>
+
+    <div ref="plotEl" class="tdp-plot" />
   </div>
 </template>
+
+<script setup>
+import { reactive, ref, onBeforeUnmount } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+import { useFalconTDP } from '~/composables/useFalconTDP';
+import { usePlotly } from '~/composables/usePlotly';
+
+const store = useFalconStore();
+const { runAnalysis } = useFalconTDP(store);
+const { mount, unmount } = usePlotly();
+
+const cfg = reactive({
+  gene: 'CETP',
+  boundary: 500000,
+  focus: 'region',
+  plotType: 'falcon',
+  minR2: 0.0,
+  maxStretch: 1.0,
+});
+
+const plotEl = ref(null);
+const ldInput = ref(null);
+const running = ref(false);
+let mountedEl = null;
+
+async function run() {
+  running.value = true;
+  try {
+    const spec = await runAnalysis({ ...cfg });
+    if (!spec || !plotEl.value) return;
+    await mount(plotEl.value, spec);
+    mountedEl = plotEl.value;
+  } catch (err) {
+    console.error('TDP runAnalysis failed:', err);
+    store.tdp.status = `Error: ${err.message || String(err)}`;
+  } finally {
+    running.value = false;
+  }
+}
+
+function triggerLdDialog() { ldInput.value?.click(); }
+async function onLdChange(e) { await store.loadLdFolder(e.target.files); }
+
+onBeforeUnmount(async () => {
+  if (mountedEl) await unmount(mountedEl);
+});
+</script>
+
+<style scoped>
+.tdp-title {
+  font-size: 1.25em;
+  font-weight: 700;
+  color: #111827;
+  margin-bottom: 8px;
+}
+.tdp-hint {
+  font-size: 0.85em;
+  color: #6b7280;
+  margin-bottom: 15px;
+}
+.tdp-toolbar {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+  background: #f9fafb;
+  padding: 15px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  align-items: center;
+}
+.input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.input-group > label {
+  font-size: 0.8em;
+  font-weight: bold;
+  color: #4b5563;
+}
+.input-group input[type='text'],
+.input-group input[type='number'],
+.input-group select {
+  padding: 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: white;
+}
+.toolbar-divider {
+  width: 0;
+  border-left: 2px dashed #d1d5db;
+  height: 40px;
+  margin: 0 5px;
+}
+.ld-label { color: #2563eb; font-weight: bold; }
+.ld-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.ld-btn {
+  padding: 6px 12px;
+  background: #eff6ff;
+  color: #1e40af;
+  border: 1px solid #93c5fd;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+}
+.ld-btn:hover { background: #dbeafe; }
+.divider-v {
+  width: 0;
+  border-left: 1px solid #d1d5db;
+  height: 20px;
+}
+.mini-input {
+  width: 50px;
+  padding: 4px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+}
+.stretch-range { width: 80px; }
+.toolbar-spacer { flex: 1; }
+.run-btn {
+  padding: 10px 20px;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+}
+.run-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.tdp-status {
+  margin-bottom: 15px;
+  color: #3b82f6;
+  font-weight: bold;
+}
+.tdp-plot {
+  width: 100%;
+  height: 850px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: white;
+}
+.hidden { display: none; }
+</style>

--- a/frontend/components/falcon-b/TraitCard.vue
+++ b/frontend/components/falcon-b/TraitCard.vue
@@ -1,0 +1,126 @@
+<template>
+  <div class="trait-card">
+    <div class="trait-card-header" @click="expanded = !expanded">
+      <span class="trait-name">{{ row.name }}</span>
+      <span class="trait-chip clump">Clump {{ row.clumpId }}</span>
+      <span v-if="row.isLead" class="trait-chip lead">⭐ Lead</span>
+      <span v-if="row.isNovel === false" class="trait-chip known">Known</span>
+      <span v-if="row.isNovel === true" class="trait-chip novel">Novel</span>
+      <span class="trait-meta">
+        Chr {{ row.chr }} · Prob {{ row.prob.toFixed(3) }} · NegP {{ row.negP.toFixed(2) }}
+      </span>
+      <span class="trait-toggle">{{ expanded ? '−' : '+' }}</span>
+    </div>
+
+    <div v-if="expanded" class="trait-card-body">
+      <div v-if="row.traits?.length" class="trait-section">
+        <h4>Associated traits</h4>
+        <ul>
+          <li v-for="(t, i) in row.traits" :key="i" class="trait-citation">
+            <span class="mono">{{ t.Trait || t.trait || '—' }}</span>
+            <span v-if="t.Citation || t.citation" class="muted">
+              ({{ t.Citation || t.citation }})
+            </span>
+          </li>
+        </ul>
+      </div>
+      <div v-if="row.clinicalTrials?.length" class="trait-section">
+        <h4>Clinical trials</h4>
+        <ul>
+          <li v-for="(t, i) in row.clinicalTrials" :key="i" class="trial-row">
+            <span class="mono">{{ t.drugId }}</span>
+            · {{ t.indication }}
+            <span class="trait-chip phase">Phase {{ t.phase }}</span>
+          </li>
+        </ul>
+      </div>
+      <div
+        v-if="!row.traits?.length && !row.clinicalTrials?.length"
+        class="muted"
+      >
+        No trait or trial data.
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+defineProps({ row: { type: Object, required: true } });
+const expanded = ref(false);
+</script>
+
+<style scoped>
+.trait-card {
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  padding: 10px 12px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  overflow-wrap: break-word;
+  word-break: break-word;
+  margin-bottom: 8px;
+  color: #111827;
+}
+.trait-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  flex-wrap: wrap;
+}
+.trait-name {
+  font-weight: 600;
+  color: #111827;
+}
+.trait-chip {
+  font-size: 0.75em;
+  padding: 2px 8px;
+  border-radius: 10px;
+  border: 1px solid #d1d5db;
+  background: #f3f4f6;
+  color: #374151;
+}
+.trait-chip.lead { background: #fef3c7; border-color: #fbbf24; color: #92400e; }
+.trait-chip.known { background: #e5e7eb; border-color: #9ca3af; color: #4b5563; }
+.trait-chip.novel { background: #d1fae5; border-color: #10b981; color: #047857; }
+.trait-chip.clump { background: #dbeafe; border-color: #60a5fa; color: #1e40af; }
+.trait-chip.phase { background: #ede9fe; border-color: #a78bfa; color: #5b21b6; }
+.trait-meta {
+  margin-left: auto;
+  font-size: 0.8em;
+  color: #6b7280;
+}
+.trait-toggle {
+  width: 18px;
+  text-align: center;
+  color: #6b7280;
+  font-weight: bold;
+}
+.trait-card-body {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px dashed #e5e7eb;
+}
+.trait-section {
+  margin-bottom: 10px;
+}
+.trait-section h4 {
+  margin: 0 0 4px 0;
+  font-size: 0.85em;
+  font-weight: 600;
+  color: #374151;
+}
+.trait-section ul {
+  list-style: disc inside;
+  font-size: 0.85em;
+  margin: 0;
+  padding: 0;
+}
+.trait-citation {
+  margin-bottom: 4px;
+  line-height: 1.4;
+}
+.mono { font-family: monospace; }
+.muted { color: #6b7280; font-size: 0.85em; }
+</style>

--- a/frontend/components/falcon-b/VariantsScatterTab.vue
+++ b/frontend/components/falcon-b/VariantsScatterTab.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
+    [VariantsScatterTab — stub; implemented in a later task]
+  </div>
+</template>

--- a/frontend/components/falcon-b/VariantsScatterTab.vue
+++ b/frontend/components/falcon-b/VariantsScatterTab.vue
@@ -1,5 +1,53 @@
 <template>
-  <div class="text-xs text-gray-400 dark:text-gray-600 py-2">
-    [VariantsScatterTab — stub; implemented in a later task]
+  <div class="space-y-4">
+    <div class="plot-wrapper">
+      <div ref="plotEl" class="w-full" style="height: 600px" />
+    </div>
   </div>
 </template>
+
+<script setup>
+import { ref, watchEffect, onBeforeUnmount, inject } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+import { useFalconPlots } from '~/composables/useFalconPlots';
+import { usePlotly } from '~/composables/usePlotly';
+
+const store = useFalconStore();
+const { buildVariantsScatterSpec } = useFalconPlots(store);
+const { mount, unmount, getPlotly } = usePlotly();
+const inspector = inject('falcon-inspector', null);
+const plotEl = ref(null);
+
+let current = null;
+let clickHandler = null;
+
+watchEffect(async () => {
+  const spec = buildVariantsScatterSpec();
+  if (!plotEl.value) return;
+  await mount(plotEl.value, spec);
+  current = plotEl.value;
+
+  await getPlotly();
+  if (clickHandler) current.removeAllListeners?.('plotly_click');
+  clickHandler = (ev) => {
+    if (!ev?.points?.length || !inspector?.value) return;
+    const p = ev.points[0];
+    const txt = p.text || p.hovertext || 'No data available.';
+    inspector.value.show(txt);
+  };
+  current.on('plotly_click', clickHandler);
+});
+
+onBeforeUnmount(async () => {
+  if (current) await unmount(current);
+});
+</script>
+
+<style scoped>
+.plot-wrapper {
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  padding: 8px;
+}
+</style>

--- a/frontend/pages/falcon-b/index.vue
+++ b/frontend/pages/falcon-b/index.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 w-full py-6 space-y-4">
+    <div class="flex items-center justify-between gap-3">
+      <div>
+        <h1 class="text-2xl font-bold">FALCON Dashboard</h1>
+        <p class="text-sm text-gray-600 dark:text-gray-400">
+          Variant B — PrimeVue shell, custom guts
+        </p>
+      </div>
+      <Tag
+        v-if="store.folderName"
+        severity="success"
+        :value="`Active Dataset: ${store.folderName}`"
+      />
+    </div>
+
+    <FolderPicker />
+    <GlobalFilterBar />
+
+    <p v-if="store.status" class="text-sm text-gray-500">{{ store.status }}</p>
+
+    <Tabs :value="activeTab" @update:value="onTabChange">
+      <TabList>
+        <Tab value="summary" :disabled="!store.datasets.genes.isLoaded">
+          Executive Summary
+        </Tab>
+        <Tab value="tdp">FALCON Zoom</Tab>
+        <Tab value="genes" :disabled="!store.datasets.genes.isLoaded">
+          Genes Plot
+        </Tab>
+        <Tab value="variants" :disabled="!store.datasets.variants.isLoaded">
+          Variants Plot
+        </Tab>
+        <Tab value="table" :disabled="!store.datasets.genes.isLoaded">
+          Data Table
+        </Tab>
+        <Tab value="log" :disabled="!store.datasets.log.isLoaded">
+          Execution Time
+        </Tab>
+      </TabList>
+
+      <TabPanels>
+        <TabPanel value="summary" :lazy="true">
+          <ExecutiveSummaryTab v-if="store.datasets.genes.isLoaded" />
+          <EmptyTab v-else reason="Load a folder to see the executive summary." />
+        </TabPanel>
+
+        <TabPanel value="tdp" :lazy="true">
+          <TDPTab />
+        </TabPanel>
+
+        <TabPanel value="genes" :lazy="true">
+          <GenesScatterTab v-if="store.datasets.genes.isLoaded" />
+          <EmptyTab v-else reason="Load a folder containing .wg.genes." />
+        </TabPanel>
+
+        <TabPanel value="variants" :lazy="true">
+          <VariantsScatterTab v-if="store.datasets.variants.isLoaded" />
+          <EmptyTab v-else reason="Load a folder containing .wg.variants." />
+        </TabPanel>
+
+        <TabPanel value="table" :lazy="true">
+          <DataTableTab v-if="store.datasets.genes.isLoaded" />
+          <EmptyTab v-else reason="Load a folder to browse the raw tables." />
+        </TabPanel>
+
+        <TabPanel value="log" :lazy="true">
+          <LogSummaryTab v-if="store.datasets.log.isLoaded" />
+          <EmptyTab v-else reason="Load a folder containing .wg.log." />
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+
+    <DataInspectorPanel ref="inspectorRef" />
+  </div>
+</template>
+
+<script setup>
+import { h, ref, provide, watch } from 'vue';
+import { useFalconStore } from '~/stores/FalconStore';
+
+const store = useFalconStore();
+const route = useRoute();
+const router = useRouter();
+const activeTab = ref(route.query.tab || 'summary');
+const inspectorRef = ref(null);
+provide('falcon-inspector', inspectorRef);
+
+// Local helper — muted empty-state message for tabs until their dataset loads.
+const EmptyTab = (props) =>
+  h(
+    'p',
+    { class: 'text-sm text-gray-500 dark:text-gray-400 py-6' },
+    props.reason || 'No data yet.',
+  );
+EmptyTab.props = ['reason'];
+
+function onTabChange(next) {
+  if (!next || next === activeTab.value) return;
+  activeTab.value = next;
+  router.push({ query: { ...route.query, tab: next } });
+}
+
+watch(
+  () => route.query.tab,
+  (next) => {
+    if (next && next !== activeTab.value) activeTab.value = next;
+  },
+);
+</script>


### PR DESCRIPTION
## Summary

Adds **Variant B** of the FALCON Results Viewer at `/falcon-b` — a "PrimeVue shell, custom guts" treatment for side-by-side pilot comparison against Variant A (`/falcon-a`, #30).

Builds on `falcon-port-base` (#29). Touches **only** `frontend/pages/falcon-b/` and `frontend/components/falcon-b/`. Zero edits to shared `stores/`, `composables/`, or `utils/`. **Disjoint file set from Variant A** — these two PRs cannot conflict.

Same six tabs as Variant A, but inner content keeps the original PEGS dashboard aesthetic:
- **Native HTML `<table>`** with sticky header and custom Prev/Next paginator (no PrimeVue DataTable)
- Original `.filter-card` + `.chr-btn` rounded pills + dual-range `<input type=range>` slider for chromosome filter
- Plain white cards with inline `<span>` stats rows for log summary (no PrimeVue Card/Tag)
- Fixed-position floating panel with original `index.html:214-226` CSS for the data inspector
- Grouped flex toolbar with native `<input>`/`<select>` for FALCON Zoom controls
- Original `.trait-card` design with color-coded chips (lead/known/novel/clump/phase) for summary rows

Outer chrome (Tabs strip, active-dataset pill, global filter bar) uses PrimeVue. Dark mode is **partial**: the chrome adapts; inner content stays in the original light palette (intentional per spec §8 — the main visual contrast vs Variant A).

Implementation plan at `docs/superpowers/plans/2026-04-24-falcon-variant-b.md` (10 tasks, ~1,720 LOC — bigger than Variant A because of the scoped CSS lifted from `PEGS/src/dashboard/styles.css`).

## Test plan

- [ ] Visit `/falcon-b` logged out → redirects to `/login`
- [ ] Logged in: chrome renders (title, subtitle "Variant B — PrimeVue shell, custom guts", **plain native folder input**, **naked flex global-filter row**)
- [ ] Tabs strip uses PrimeVue but tab content uses original CSS
- [ ] Load a folder → tabs unlock
- [ ] Each tab renders without console errors
- [ ] Genes Plot: original 🧬 filter card with rounded `.chr-btn` pills, dual-range BP slider
- [ ] Data Table: native HTML table with sticky header, click-to-sort with arrow indicator, Prev/Next paginator
- [ ] FALCON Zoom: gray-background flex toolbar, blue-accent LD button, primary blue Run Analysis
- [ ] Click a Plotly point on Genes Plot → fixed-position inspector panel pops up bottom-right with original CSS
- [ ] Toggle dark mode → outer chrome adapts; inner content stays light (intentional)
- [ ] Reload a different dataset → cache reset works

## Dependencies

This PR currently includes the commits from `falcon-port-base` (#29). After that PR merges to `main`, this PR's diff will auto-shrink to just the Variant B files. Reviewers can focus on `pages/falcon-b/**` and `components/falcon-b/**`.

## After both variants merge

A short cleanup PR (`falcon-cleanup`) per spec §13 will delete the loser's directory and optionally rename the winner's path to `/falcon`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)