### PR TITLE
fix(falcon-a): bug fixes + restore Executive Summary plots (missed by #30)

### DIFF
--- a/frontend/components/falcon-a/ExecutiveSummaryTab.vue
+++ b/frontend/components/falcon-a/ExecutiveSummaryTab.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="space-y-6">
-    <div class="flex items-center gap-3">
+    <div class="flex items-center gap-3 flex-wrap">
       <Button
         icon="pi pi-database"
         :label="
@@ -13,11 +13,24 @@
       />
       <Button
         :icon="showNovel ? 'pi pi-star-fill' : 'pi pi-star'"
-        :label="showNovel ? 'Novelty filter: ON' : 'Novelty filter: OFF'"
+        :label="
+          noveltyLoading
+            ? 'Loading novelty…'
+            : showNovel
+              ? 'Novelty filter: ON'
+              : 'Novelty filter: OFF'
+        "
         severity="secondary"
         outlined
+        :loading="noveltyLoading"
         @click="toggleNovelty"
       />
+      <span
+        v-if="noveltyError"
+        class="text-xs text-red-600 dark:text-red-400 ml-2"
+      >
+        Novelty fetch failed — see console.
+      </span>
       <input
         ref="trialsInput"
         type="file"
@@ -27,48 +40,39 @@
       />
     </div>
 
-    <section>
-      <h3 class="text-lg font-semibold mb-2">Top Genes per Clump</h3>
-      <TraitCard
-        v-for="row in filteredGenesTop"
-        :key="`g-top-${row.index}`"
-        :row="row"
-      />
-    </section>
+    <SummarySection
+      title="Top Genes per Clump"
+      :rows="summary.genes?.top || []"
+      :show-novelty="true"
+      :show-novel-filter="showNovel"
+    />
 
-    <section>
-      <h3 class="text-lg font-semibold mb-2">Lead Genes per Chromosome</h3>
-      <TraitCard
-        v-for="row in filteredGenesLead"
-        :key="`g-lead-${row.index}`"
-        :row="row"
-      />
-    </section>
+    <SummarySection
+      title="Lead Genes per Chromosome"
+      :rows="summary.genes?.lead || []"
+      :show-novelty="true"
+      :show-novel-filter="showNovel"
+    />
 
-    <section>
-      <h3 class="text-lg font-semibold mb-2">Top Variants per Clump</h3>
-      <TraitCard
-        v-for="row in summary.variants?.top || []"
-        :key="`v-top-${row.index}`"
-        :row="row"
-      />
-    </section>
+    <SummarySection
+      title="Top Variants per Clump"
+      :rows="summary.variants?.top || []"
+      :show-novelty="false"
+    />
 
-    <section>
-      <h3 class="text-lg font-semibold mb-2">Lead Variants per Chromosome</h3>
-      <TraitCard
-        v-for="row in summary.variants?.lead || []"
-        :key="`v-lead-${row.index}`"
-        :row="row"
-      />
-    </section>
+    <SummarySection
+      title="Lead Variants per Chromosome"
+      :rows="summary.variants?.lead || []"
+      :show-novelty="false"
+    />
   </div>
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue';
+import { computed, h, ref, watch } from 'vue';
 import { useFalconStore } from '~/stores/FalconStore';
 import { useFalconSummary } from '~/composables/useFalconSummary';
+import TraitCard from '~/components/falcon-a/TraitCard.vue';
 
 const store = useFalconStore();
 const { computeTopAndLeadSignals, attachClinicalTrials, attachNoveltyFlags } =
@@ -80,6 +84,8 @@ const summary = ref({
   variants: { top: [], lead: [] },
 });
 const showNovel = ref(false);
+const noveltyLoading = ref(false);
+const noveltyError = ref(false);
 let abortCtrl = null;
 
 watch(
@@ -101,32 +107,32 @@ function recompute() {
   summary.value = s;
 }
 
-const filteredGenesTop = computed(() =>
-  showNovel.value
-    ? (summary.value.genes?.top || []).filter((r) => r.isNovel === true)
-    : summary.value.genes?.top || [],
-);
-
-const filteredGenesLead = computed(() =>
-  showNovel.value
-    ? (summary.value.genes?.lead || []).filter((r) => r.isNovel === true)
-    : summary.value.genes?.lead || [],
-);
-
 async function toggleNovelty() {
-  showNovel.value = !showNovel.value;
+  // If we are turning OFF, just flip the flag — don't touch cached traits.
   if (showNovel.value) {
-    if (abortCtrl) abortCtrl.abort();
-    abortCtrl = new AbortController();
-    const all = [
-      ...summary.value.genes.top,
-      ...summary.value.genes.lead,
-    ];
-    try {
-      await attachNoveltyFlags(all, abortCtrl.signal);
-    } catch (err) {
-      if (err.name !== 'AbortError') console.error(err);
+    showNovel.value = false;
+    return;
+  }
+
+  // Turn ON: fetch novelty for every gene row in either gene section.
+  if (abortCtrl) abortCtrl.abort();
+  abortCtrl = new AbortController();
+  noveltyLoading.value = true;
+  noveltyError.value = false;
+  const all = [
+    ...(summary.value.genes.top || []),
+    ...(summary.value.genes.lead || []),
+  ];
+  try {
+    await attachNoveltyFlags(all, abortCtrl.signal);
+    showNovel.value = true;
+  } catch (err) {
+    if (err.name !== 'AbortError') {
+      console.error('[ExecutiveSummaryTab] novelty fetch failed', err);
+      noveltyError.value = true;
     }
+  } finally {
+    noveltyLoading.value = false;
   }
 }
 
@@ -144,4 +150,153 @@ async function onTrialsFile(e) {
     console.error('clinical trials load failed', err);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Inline section component: per-section search + role filter + paginator,
+// porting SummaryModule.buildInteractiveTable filtering UX (PEGS app.js:1350+).
+// Inline rather than a separate file to keep the variant-A blast radius small.
+// ---------------------------------------------------------------------------
+const ROLE_OPTIONS = [
+  { value: 'all', label: 'All Roles' },
+  { value: 'top', label: 'Top Only' },
+  { value: 'lead', label: 'Lead Only' },
+  { value: 'both', label: 'Top & Lead' },
+];
+
+const SummarySection = {
+  props: {
+    title: { type: String, required: true },
+    rows: { type: Array, required: true },
+    showNovelty: { type: Boolean, default: false },
+    showNovelFilter: { type: Boolean, default: false },
+  },
+  setup(props) {
+    const search = ref('');
+    const roleFilter = ref('all');
+    const page = ref(1);
+    const pageSize = 10;
+
+    // The shape coming out of useFalconSummary doesn't carry an explicit
+    // "role" — top rows live in .top, leads in .lead. The same gene can
+    // appear in both. Detect "both" by intersecting names within this list.
+    const filtered = computed(() => {
+      const list = props.rows || [];
+      const q = search.value.trim().toLowerCase();
+      return list.filter((row) => {
+        if (roleFilter.value === 'top' && row.isLead) return false;
+        if (roleFilter.value === 'lead' && !row.isLead) return false;
+        // "both" is approximate without cross-list info — treat as "isLead".
+        if (roleFilter.value === 'both' && !row.isLead) return false;
+
+        if (props.showNovelFilter) {
+          if (row.isNovel === null || row.isNovel === undefined) return false;
+          if (row.isNovel !== true) return false;
+        }
+
+        if (q) {
+          const hay =
+            `${row.name || ''} ${row.clumpId || ''} ${row.chr || ''}`.toLowerCase();
+          if (!hay.includes(q)) return false;
+        }
+        return true;
+      });
+    });
+
+    const totalPages = computed(() =>
+      Math.max(1, Math.ceil(filtered.value.length / pageSize)),
+    );
+    const pageRows = computed(() => {
+      const start = (page.value - 1) * pageSize;
+      return filtered.value.slice(start, start + pageSize);
+    });
+
+    // Reset to page 1 if filters narrow the list past current page.
+    watch([search, roleFilter, () => props.rows.length, () => props.showNovelFilter], () => {
+      if (page.value > totalPages.value) page.value = totalPages.value;
+      if (page.value < 1) page.value = 1;
+    });
+
+    return () =>
+      h('section', {}, [
+        h(
+          'div',
+          { class: 'flex items-end gap-3 flex-wrap mb-2' },
+          [
+            h(
+              'h3',
+              { class: 'text-lg font-semibold mr-auto' },
+              `${props.title} (${filtered.value.length})`,
+            ),
+            h(
+              'select',
+              {
+                class:
+                  'border rounded px-2 py-1 text-sm bg-white dark:bg-gray-900 dark:border-gray-700',
+                value: roleFilter.value,
+                onChange: (e) => {
+                  roleFilter.value = e.target.value;
+                  page.value = 1;
+                },
+              },
+              ROLE_OPTIONS.map((o) =>
+                h('option', { value: o.value, key: o.value }, o.label),
+              ),
+            ),
+            h('input', {
+              type: 'text',
+              placeholder: 'Search…',
+              class:
+                'border rounded px-2 py-1 text-sm w-48 bg-white dark:bg-gray-900 dark:border-gray-700',
+              value: search.value,
+              onInput: (e) => {
+                search.value = e.target.value;
+                page.value = 1;
+              },
+            }),
+          ],
+        ),
+        ...pageRows.value.map((row) =>
+          h(TraitCard, {
+            key: `${props.title}-${row.index}`,
+            row,
+          }),
+        ),
+        filtered.value.length === 0
+          ? h(
+              'p',
+              { class: 'text-sm text-gray-500 dark:text-gray-400 py-2' },
+              'No matching rows.',
+            )
+          : null,
+        h(
+          'div',
+          { class: 'flex items-center gap-2 mt-2 text-sm' },
+          [
+            h(
+              'button',
+              {
+                class:
+                  'px-2 py-1 border rounded disabled:opacity-50 dark:border-gray-700',
+                disabled: page.value <= 1,
+                onClick: () => (page.value = Math.max(1, page.value - 1)),
+              },
+              'Previous',
+            ),
+            h('span', {}, `Page ${page.value} of ${totalPages.value}`),
+            h(
+              'button',
+              {
+                class:
+                  'px-2 py-1 border rounded disabled:opacity-50 dark:border-gray-700',
+                disabled: page.value >= totalPages.value,
+                onClick: () =>
+                  (page.value = Math.min(totalPages.value, page.value + 1)),
+              },
+              'Next',
+            ),
+          ],
+        ),
+      ]);
+  },
+};
 </script>

--- a/frontend/components/falcon-a/ExecutiveSummaryTab.vue
+++ b/frontend/components/falcon-a/ExecutiveSummaryTab.vue
@@ -40,6 +40,122 @@
       />
     </div>
 
+    <!-- ─── Executive Summary Plots (row 1: upset + venn) ─── -->
+    <div class="grid gap-4" style="grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));">
+      <Card>
+        <template #title>🧬 Gene Intersection: Top, Lead, and Novel</template>
+        <template #content>
+          <p class="text-sm text-gray-600 dark:text-gray-300 mb-2">
+            <strong>Top Genes</strong> are highest probability targets.
+            <strong>Lead Genes</strong> are physically nearest.
+            <strong>Novel Genes</strong> have no previous associations in our catalog.
+            <strong>Clinical Trials</strong> indicates genes with known clinical data.
+          </p>
+          <div class="relative" style="height: 350px">
+            <div ref="upsetEl" class="w-full h-full" />
+            <div
+              v-if="upsetSpec?.empty"
+              class="absolute inset-0 flex items-center justify-center text-sm text-gray-500 dark:text-gray-400 pointer-events-none"
+            >
+              No intersection data.
+            </div>
+          </div>
+        </template>
+      </Card>
+
+      <Card>
+        <template #title>🔬 Variant Overlap: Top vs. Lead</template>
+        <template #content>
+          <p class="text-sm text-gray-600 dark:text-gray-300 mb-2">
+            <strong>Top Variants</strong> are the variants with the highest FALCON probability in their clump.
+            <strong>Lead Variants</strong> represent the index signal of the clump.
+            This diagram shows how often the model's top variant matches the original index signal.
+          </p>
+          <div class="relative" style="height: 280px">
+            <div ref="vennEl" class="w-full h-full" />
+          </div>
+        </template>
+      </Card>
+    </div>
+
+    <!-- ─── row 2: probability distributions ─── -->
+    <div class="grid gap-4" style="grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));">
+      <Card>
+        <template #title>📊 Gene Probability Distribution</template>
+        <template #content>
+          <p class="text-sm text-gray-600 dark:text-gray-300 mb-2">
+            Distribution of FALCON probabilities across the Top, Lead, and Concordant gene categories.
+          </p>
+          <div class="relative" style="height: 260px">
+            <div ref="probGenesEl" class="w-full h-full" />
+            <div
+              v-if="probGenesSpec?.empty"
+              class="absolute inset-0 flex items-center justify-center text-sm text-gray-500 dark:text-gray-400 pointer-events-none"
+            >
+              No gene probability data.
+            </div>
+          </div>
+        </template>
+      </Card>
+
+      <Card>
+        <template #title>📊 Variant Probability Distribution</template>
+        <template #content>
+          <p class="text-sm text-gray-600 dark:text-gray-300 mb-2">
+            Distribution of FALCON probabilities across the Top, Lead, and Concordant variant categories.
+          </p>
+          <div class="relative" style="height: 260px">
+            <div ref="probVariantsEl" class="w-full h-full" />
+            <div
+              v-if="probVariantsSpec?.empty"
+              class="absolute inset-0 flex items-center justify-center text-sm text-gray-500 dark:text-gray-400 pointer-events-none"
+            >
+              No variant probability data.
+            </div>
+          </div>
+        </template>
+      </Card>
+    </div>
+
+    <!-- ─── row 3: distance plots ─── -->
+    <div class="grid gap-4" style="grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));">
+      <Card>
+        <template #title>📏 Distance to Nearest Gene</template>
+        <template #content>
+          <p class="text-sm text-gray-600 dark:text-gray-300 mb-2">
+            Physical distance (BP) from the <strong>Index Variant</strong> to its designated <strong>Lead Gene</strong>.
+          </p>
+          <div class="relative" style="height: 260px">
+            <div ref="distEl" class="w-full h-full" />
+            <div
+              v-if="distSpec?.empty"
+              class="absolute inset-0 flex items-center justify-center text-sm text-gray-500 dark:text-gray-400 pointer-events-none"
+            >
+              No distance data available.
+            </div>
+          </div>
+        </template>
+      </Card>
+
+      <Card>
+        <template #title>📏 Distance Between Lead Variants</template>
+        <template #content>
+          <p class="text-sm text-gray-600 dark:text-gray-300 mb-2">
+            Physical distance (BP) between adjacent <strong>Index Variants</strong> across the same chromosome.
+          </p>
+          <div class="relative" style="height: 260px">
+            <div ref="leadDistEl" class="w-full h-full" />
+            <div
+              v-if="leadDistSpec?.empty"
+              class="absolute inset-0 flex items-center justify-center text-sm text-gray-500 dark:text-gray-400 pointer-events-none"
+            >
+              Not enough adjacent lead variants available to measure distances.
+            </div>
+          </div>
+        </template>
+      </Card>
+    </div>
+
     <SummarySection
       title="Top Genes per Clump"
       :rows="summary.genes?.top || []"
@@ -69,14 +185,29 @@
 </template>
 
 <script setup>
-import { computed, h, ref, watch } from 'vue';
+import { computed, h, onBeforeUnmount, ref, watch, watchEffect } from 'vue';
 import { useFalconStore } from '~/stores/FalconStore';
 import { useFalconSummary } from '~/composables/useFalconSummary';
+import { useFalconPlots } from '~/composables/useFalconPlots';
+import { usePlotly } from '~/composables/usePlotly';
 import TraitCard from '~/components/falcon-a/TraitCard.vue';
 
 const store = useFalconStore();
-const { computeTopAndLeadSignals, attachClinicalTrials, attachNoveltyFlags } =
-  useFalconSummary(store);
+const {
+  computeTopAndLeadSignals,
+  attachClinicalTrials,
+  attachNoveltyFlags,
+  computeSummaryRowsForPlots,
+  computeDistances,
+} = useFalconSummary(store);
+const {
+  buildSummaryUpsetSpec,
+  buildSummaryVennSpec,
+  buildSummaryProbDistSpec,
+  buildSummaryDistanceSpec,
+  buildSummaryLeadDistanceSpec,
+} = useFalconPlots(store);
+const { mount, unmount } = usePlotly();
 
 const clinicalTrials = store.clinicalTrials;
 const summary = ref({
@@ -88,11 +219,35 @@ const noveltyLoading = ref(false);
 const noveltyError = ref(false);
 let abortCtrl = null;
 
+// Plot-shaped summary data and refs.
+const genesPlotRows = ref([]);
+const variantsPlotRows = ref([]);
+const variantsStats = ref({ topOnly: 0, leadOnly: 0, both: 0 });
+const distances = ref([]);
+const leadDistances = ref([]);
+
+const upsetEl = ref(null);
+const vennEl = ref(null);
+const probGenesEl = ref(null);
+const probVariantsEl = ref(null);
+const distEl = ref(null);
+const leadDistEl = ref(null);
+
+const upsetSpec = computed(() => buildSummaryUpsetSpec(genesPlotRows.value));
+const vennSpec = computed(() => buildSummaryVennSpec(variantsStats.value));
+const probGenesSpec = computed(() => buildSummaryProbDistSpec(genesPlotRows.value));
+const probVariantsSpec = computed(() => buildSummaryProbDistSpec(variantsPlotRows.value));
+const distSpec = computed(() => buildSummaryDistanceSpec(distances.value));
+const leadDistSpec = computed(() => buildSummaryLeadDistanceSpec(leadDistances.value));
+
 watch(
   () => [
     store.datasets.genes.isLoaded,
     store.datasets.variants.isLoaded,
     clinicalTrials.isLoaded,
+    store.globalFilter.active,
+    store.globalFilter.minProb,
+    store.globalFilter.minNegP,
   ],
   recompute,
   { immediate: true },
@@ -105,7 +260,54 @@ function recompute() {
     attachClinicalTrials(s.variants[k]);
   });
   summary.value = s;
+
+  // Plot-shaped rows. `isNovel` starts null per original behaviour.
+  const genes = computeSummaryRowsForPlots('genes');
+  const variants = computeSummaryRowsForPlots('variants');
+  genesPlotRows.value = genes.results;
+  variantsPlotRows.value = variants.results;
+  variantsStats.value = variants.stats;
+
+  const d = computeDistances();
+  distances.value = d.distances;
+  leadDistances.value = d.leadDistances;
 }
+
+function mountPlot(el, spec) {
+  if (!el || !spec) return;
+  if (spec.empty) {
+    // Still mount so Plotly can draw an empty axis frame; the overlay in
+    // the template shows the placeholder text.
+    mount(el, spec);
+    return;
+  }
+  mount(el, spec);
+}
+
+watchEffect(() => {
+  mountPlot(upsetEl.value, upsetSpec.value);
+});
+watchEffect(() => {
+  mountPlot(vennEl.value, vennSpec.value);
+});
+watchEffect(() => {
+  mountPlot(probGenesEl.value, probGenesSpec.value);
+});
+watchEffect(() => {
+  mountPlot(probVariantsEl.value, probVariantsSpec.value);
+});
+watchEffect(() => {
+  mountPlot(distEl.value, distSpec.value);
+});
+watchEffect(() => {
+  mountPlot(leadDistEl.value, leadDistSpec.value);
+});
+
+onBeforeUnmount(async () => {
+  for (const el of [upsetEl, vennEl, probGenesEl, probVariantsEl, distEl, leadDistEl]) {
+    if (el.value) await unmount(el.value);
+  }
+});
 
 async function toggleNovelty() {
   // If we are turning OFF, just flip the flag — don't touch cached traits.

--- a/frontend/components/falcon-a/GenesScatterTab.vue
+++ b/frontend/components/falcon-a/GenesScatterTab.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script setup>
-import { ref, watchEffect, onBeforeUnmount, inject } from 'vue';
+import { ref, watchEffect, onBeforeUnmount, onActivated, onMounted, inject, nextTick } from 'vue';
 import { useFalconStore } from '~/stores/FalconStore';
 import { useFalconPlots } from '~/composables/useFalconPlots';
 import { usePlotly } from '~/composables/usePlotly';
@@ -40,6 +40,21 @@ watchEffect(async () => {
   };
   current.on('plotly_click', clickHandler);
 });
+
+// Re-resize after activation in case the plot was first laid out while the
+// parent tab panel was still display:none.
+async function nudgeResize() {
+  if (!current) return;
+  const Plotly = await getPlotly();
+  await nextTick();
+  try {
+    if (current.offsetParent !== null) Plotly.Plots.resize(current);
+  } catch {
+    // ignore
+  }
+}
+onMounted(nudgeResize);
+onActivated(nudgeResize);
 
 onBeforeUnmount(async () => {
   if (current) await unmount(current);

--- a/frontend/components/falcon-a/LogSummaryTab.vue
+++ b/frontend/components/falcon-a/LogSummaryTab.vue
@@ -4,7 +4,7 @@
       <h3 class="text-xl font-semibold">FALCON Execution Time Summary</h3>
       <Tag
         severity="success"
-        :value="`Total Execution Time: ${totalTime}`"
+        :value="`Total Execution Time: ${formattedTotalTime}`"
         class="text-base"
       />
     </div>
@@ -48,7 +48,47 @@
       />
     </div>
 
-    <div ref="preprocessEl" class="w-full" style="height: 320px" />
+    <Card>
+      <template #title>
+        <div class="flex items-center justify-between gap-3 flex-wrap">
+          <span>Pre-process Steps Accumulation Time</span>
+          <Tag
+            severity="success"
+            :value="`${preProcess.parallel ? 'Total Pre-process (Parallel Wall Time)' : 'Total Pre-process'}: ${formatTime(preProcess.totalTime)}`"
+          />
+        </div>
+      </template>
+      <template #content>
+        <div
+          class="grid gap-2"
+          style="grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));"
+        >
+          <div
+            v-for="step in preProcess.perStep"
+            :key="step.key"
+            class="flex justify-between items-center px-3 py-2 rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-sm"
+          >
+            <span class="text-gray-500 dark:text-gray-400">{{ step.key }}</span>
+            <strong
+              :class="
+                step.time === 0
+                  ? 'text-red-500 font-normal'
+                  : 'text-emerald-700 dark:text-emerald-400'
+              "
+            >
+              {{ step.time === 0 ? 'Skipped / 0.00s' : `${step.time.toFixed(2)}s` }}
+            </strong>
+          </div>
+        </div>
+      </template>
+    </Card>
+
+    <Card>
+      <template #title>Total Pre-process Time by Chromosome</template>
+      <template #content>
+        <div ref="preprocessEl" class="w-full" style="height: 320px" />
+      </template>
+    </Card>
 
     <div
       class="grid gap-4"
@@ -102,12 +142,32 @@ import { useFalconLogParser } from '~/composables/useFalconLogParser';
 import { usePlotly } from '~/composables/usePlotly';
 
 const store = useFalconStore();
-const { buildLogIterHistogramSpec, buildLogPreprocessBarSpec } =
-  useFalconPlots(store);
-const { ITER_COMPONENTS: components } = useFalconLogParser();
+const {
+  buildLogIterHistogramSpec,
+  buildLogPreprocessBarSpec,
+  buildLogPreprocessByStepSpec,
+} = useFalconPlots(store);
+const { ITER_COMPONENTS: components, PRE_PROCESS_KEYS } = useFalconLogParser();
 const { mount, unmount } = usePlotly();
 
+function formatTime(seconds) {
+  if (!isFinite(seconds) || seconds <= 0) return '0.00s';
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = (seconds % 60).toFixed(2);
+  const parts = [];
+  if (h > 0) parts.push(`${h}h`);
+  if (m > 0 || h > 0) parts.push(`${m}m`);
+  parts.push(`${s}s`);
+  return `${parts.join(' ')} (${seconds.toFixed(2)}s)`;
+}
+
 const chrView = ref('all');
+
+const preProcess = computed(() =>
+  buildLogPreprocessByStepSpec(chrView.value, PRE_PROCESS_KEYS),
+);
+
 const chrOptions = computed(() => {
   const chrs = Array.from(store.datasets.log.chromosomes).sort((a, b) => {
     const na = parseInt(a, 10),
@@ -122,6 +182,15 @@ const chrOptions = computed(() => {
 });
 
 const totalTime = computed(() => store.datasets.log.totalTime);
+
+// Reformat the parsed totalTime ("6149.27 seconds") into h/m/s + raw,
+// matching LogSummaryModule.render (PEGS app.js:2531-2548). When the parser
+// found no total (string "Not Found / Incomplete Run"), pass it through.
+const formattedTotalTime = computed(() => {
+  const raw = parseFloat(totalTime.value);
+  if (isNaN(raw)) return totalTime.value || 'No log file detected.';
+  return formatTime(raw);
+});
 
 const preprocessEl = ref(null);
 const histRefs = ref({});
@@ -142,7 +211,7 @@ const compStats = computed(() => {
 
 watchEffect(async () => {
   if (preprocessEl.value) {
-    await mount(preprocessEl.value, buildLogPreprocessBarSpec());
+    await mount(preprocessEl.value, buildLogPreprocessBarSpec(chrView.value));
     mounted.add(preprocessEl.value);
   }
   for (const comp of components) {

--- a/frontend/components/falcon-a/TDPTab.vue
+++ b/frontend/components/falcon-a/TDPTab.vue
@@ -45,8 +45,8 @@
         <Card class="mt-4 !bg-blue-50 dark:!bg-blue-950/40">
           <template #title>LD Matrix</template>
           <template #content>
-            <div class="flex flex-wrap items-end gap-3">
-              <div class="flex flex-col gap-1">
+            <div class="flex flex-wrap items-end gap-x-6 gap-y-4">
+              <div class="flex flex-col gap-1 shrink-0">
                 <label class="text-xs font-semibold"
                   >LD Folder (.gz / .sorted)</label
                 >
@@ -68,7 +68,7 @@
                   />
                 </div>
               </div>
-              <div class="flex flex-col gap-1">
+              <div class="flex flex-col gap-1 shrink-0 w-40">
                 <label class="text-xs font-semibold">Min R²</label>
                 <InputNumber
                   v-model="cfg.minR2"
@@ -77,19 +77,22 @@
                   :step="0.1"
                   :min-fraction-digits="1"
                   :max-fraction-digits="2"
-                  class="w-28"
+                  :input-style="{ width: '100%' }"
+                  fluid
                 />
               </div>
-              <div class="flex flex-col gap-1 min-w-[160px]">
+              <div class="flex flex-col gap-2 shrink-0 w-64">
                 <label class="text-xs font-semibold"
                   >Max Stretch: {{ cfg.maxStretch.toFixed(2) }}</label
                 >
-                <Slider
-                  v-model="cfg.maxStretch"
-                  :min="0.1"
-                  :max="1"
-                  :step="0.05"
-                />
+                <div class="px-2 pt-3">
+                  <Slider
+                    v-model="cfg.maxStretch"
+                    :min="0.1"
+                    :max="1"
+                    :step="0.05"
+                  />
+                </div>
               </div>
             </div>
           </template>
@@ -124,14 +127,15 @@
 </template>
 
 <script setup>
-import { ref, reactive, onBeforeUnmount } from 'vue';
+import { ref, reactive, onBeforeUnmount, inject } from 'vue';
 import { useFalconStore } from '~/stores/FalconStore';
 import { useFalconTDP } from '~/composables/useFalconTDP';
 import { usePlotly } from '~/composables/usePlotly';
 
 const store = useFalconStore();
 const { runAnalysis } = useFalconTDP(store);
-const { mount, unmount } = usePlotly();
+const { mount, unmount, getPlotly } = usePlotly();
+const inspector = inject('falcon-inspector', null);
 
 const cfg = reactive({
   gene: 'CETP',
@@ -156,6 +160,7 @@ const plotEl = ref(null);
 const ldInput = ref(null);
 const running = ref(false);
 let mountedEl = null;
+let clickHandler = null;
 
 async function run() {
   running.value = true;
@@ -164,6 +169,18 @@ async function run() {
     if (!spec || !plotEl.value) return;
     await mount(plotEl.value, spec);
     mountedEl = plotEl.value;
+
+    // Restore InspectorModule.bindToPlot pattern (PEGS app.js:2862-2872):
+    // clicking a point opens the Data Inspector with the point's HTML text.
+    await getPlotly();
+    if (clickHandler) mountedEl.removeAllListeners?.('plotly_click');
+    clickHandler = (ev) => {
+      if (!ev?.points?.length || !inspector?.value) return;
+      const p = ev.points[0];
+      const txt = p.text || p.hovertext || 'No data available for this point.';
+      inspector.value.show(txt);
+    };
+    mountedEl.on('plotly_click', clickHandler);
   } catch (err) {
     console.error('TDP runAnalysis failed:', err);
     store.tdp.status = `Error: ${err.message || String(err)}`;

--- a/frontend/components/falcon-a/VariantsScatterTab.vue
+++ b/frontend/components/falcon-a/VariantsScatterTab.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup>
-import { ref, watchEffect, onBeforeUnmount, inject } from 'vue';
+import { ref, watchEffect, onBeforeUnmount, onActivated, onMounted, inject, nextTick } from 'vue';
 import { useFalconStore } from '~/stores/FalconStore';
 import { useFalconPlots } from '~/composables/useFalconPlots';
 import { usePlotly } from '~/composables/usePlotly';
@@ -39,6 +39,19 @@ watchEffect(async () => {
   };
   current.on('plotly_click', clickHandler);
 });
+
+async function nudgeResize() {
+  if (!current) return;
+  const Plotly = await getPlotly();
+  await nextTick();
+  try {
+    if (current.offsetParent !== null) Plotly.Plots.resize(current);
+  } catch {
+    // ignore
+  }
+}
+onMounted(nudgeResize);
+onActivated(nudgeResize);
 
 onBeforeUnmount(async () => {
   if (current) await unmount(current);

--- a/frontend/composables/useFalconPlots.js
+++ b/frontend/composables/useFalconPlots.js
@@ -227,8 +227,9 @@ export function useFalconPlots(store) {
 
   /**
    * Per-chromosome total pre-process time bar chart.
+   * `chrView` highlights one chromosome in green if not 'all'.
    */
-  function buildLogPreprocessBarSpec() {
+  function buildLogPreprocessBarSpec(chrView /* 'all' | chromosome */) {
     const logStore = store.datasets.log;
     const chrs = Array.from(logStore.chromosomes).sort((a, b) => {
       const na = parseInt(a, 10);
@@ -240,11 +241,13 @@ export function useFalconPlots(store) {
       const pp = logStore.preProcess[chr] || {};
       return Object.values(pp).reduce((a, b) => a + b, 0);
     });
-    const colors = chrs.map((_, i) => FALCON_PALETTE[i % FALCON_PALETTE.length]);
+    const colors = chrs.map((c) =>
+      chrView && chrView !== "all" && chrView === c ? "#047857" : "#3b82f6",
+    );
     return {
       data: [
         {
-          x: chrs,
+          x: chrs.map((c) => `Chr ${c}`),
           y: totals,
           type: "bar",
           marker: { color: colors },
@@ -264,10 +267,58 @@ export function useFalconPlots(store) {
     };
   }
 
+  /**
+   * Pre-process step accumulation summary, mirroring LogSummaryModule.drawPlots
+   * (PEGS app.js:2584-2636).
+   *
+   * For chrView='all': totalTime = parallel-wall-time bottleneck (max chr total),
+   * and per-step values = max value across chromosomes (worst-case worker).
+   * For a specific chromosome: just the values for that chromosome.
+   *
+   * Returns { perStep: [{ key, time }], totalTime, parallel: bool }.
+   */
+  function buildLogPreprocessByStepSpec(chrView /* 'all' | chromosome */, preProcessKeys) {
+    const logStore = store.datasets.log;
+    const perStep = preProcessKeys.map((k) => ({ key: k, time: 0 }));
+    let totalTime = 0;
+    const parallel = chrView === "all";
+
+    if (parallel) {
+      // Wall-time bottleneck = the slowest single chromosome's total.
+      let maxChrTotal = 0;
+      Object.keys(logStore.preProcess).forEach((chr) => {
+        let chrTotal = 0;
+        preProcessKeys.forEach((k) => {
+          chrTotal += logStore.preProcess[chr][k] || 0;
+        });
+        if (chrTotal > maxChrTotal) maxChrTotal = chrTotal;
+      });
+      totalTime = maxChrTotal;
+
+      // Per-step worst case across workers.
+      preProcessKeys.forEach((k, i) => {
+        let maxVal = 0;
+        Object.keys(logStore.preProcess).forEach((chr) => {
+          maxVal = Math.max(maxVal, logStore.preProcess[chr][k] || 0);
+        });
+        perStep[i].time = maxVal;
+      });
+    } else if (logStore.preProcess[chrView]) {
+      preProcessKeys.forEach((k, i) => {
+        const v = logStore.preProcess[chrView][k] || 0;
+        perStep[i].time = v;
+        totalTime += v;
+      });
+    }
+
+    return { perStep, totalTime, parallel };
+  }
+
   return {
     buildGenesScatterSpec,
     buildVariantsScatterSpec,
     buildLogIterHistogramSpec,
     buildLogPreprocessBarSpec,
+    buildLogPreprocessByStepSpec,
   };
 }

--- a/frontend/composables/useFalconPlots.js
+++ b/frontend/composables/useFalconPlots.js
@@ -314,11 +314,332 @@ export function useFalconPlots(store) {
     return { perStep, totalTime, parallel };
   }
 
+  // -------------------------------------------------------------------
+  // Executive Summary plot spec builders.
+  // Ported verbatim from PEGS app.js SummaryModule.drawUpsetPlot (1083-1208),
+  // drawVennDiagram (1210-1234), drawProbDistributionPlot (1236-1273),
+  // drawDistancePlot (1275-1310), drawLeadDistancePlot (1313-1349).
+  // Each returns { data, layout } (plus `empty: true` when nothing to draw).
+  // -------------------------------------------------------------------
+  function buildSummaryUpsetSpec(plotRows) {
+    const setNames = ["Top", "Lead", "Novel", "Clinical Trials"];
+    const combinations = [];
+    for (let i = 1; i < 1 << setNames.length; i++) {
+      const sets = [];
+      for (let j = 0; j < setNames.length; j++) {
+        if ((i >> j) & 1) sets.push(setNames[j]);
+      }
+      combinations.push({ sets, count: 0 });
+    }
+
+    (plotRows || []).forEach((d) => {
+      const flags = {
+        Top: d.role && d.role.includes("Top"),
+        Lead: d.role && d.role.includes("Lead"),
+        Novel: d.isNovel === true,
+        "Clinical Trials": d.hasClinicalTrials === true,
+      };
+      const combo = combinations.find((c) =>
+        setNames.every((s) => flags[s] === c.sets.includes(s)),
+      );
+      if (combo) combo.count++;
+    });
+
+    const plotData = combinations
+      .filter((c) => c.count > 0)
+      .sort((a, b) => b.count - a.count);
+
+    if (plotData.length === 0) {
+      return {
+        data: [],
+        layout: {
+          margin: { t: 40, l: 100, r: 20, b: 40 },
+          plot_bgcolor: "rgba(0,0,0,0)",
+          paper_bgcolor: "rgba(0,0,0,0)",
+        },
+        empty: true,
+      };
+    }
+
+    const xValues = plotData.map((_, i) => i);
+    const barCounts = plotData.map((c) => c.count);
+
+    const traceBar = {
+      x: xValues,
+      y: barCounts,
+      type: "bar",
+      name: "Intersection Size",
+      marker: { color: "#93c5fd" },
+      xaxis: "x",
+      yaxis: "y",
+      hovertemplate: "%{y}<extra></extra>",
+    };
+
+    const matrixTraces = [];
+    setNames.forEach((setName, setIdx) => {
+      matrixTraces.push({
+        x: xValues,
+        y: Array(xValues.length).fill(setIdx),
+        mode: "markers",
+        marker: { color: "#e5e7eb", size: 12 },
+        showlegend: false,
+        xaxis: "x",
+        yaxis: "y2",
+        hoverinfo: "none",
+      });
+    });
+
+    plotData.forEach((combo, xIdx) => {
+      const activeIdx = [];
+      setNames.forEach((setName, setIdx) => {
+        if (combo.sets.includes(setName)) activeIdx.push(setIdx);
+      });
+
+      if (activeIdx.length > 1) {
+        matrixTraces.push({
+          x: [xIdx, xIdx],
+          y: [Math.min(...activeIdx), Math.max(...activeIdx)],
+          mode: "lines",
+          line: { color: "#1f2937", width: 3 },
+          showlegend: false,
+          xaxis: "x",
+          yaxis: "y2",
+          hoverinfo: "none",
+        });
+      }
+
+      matrixTraces.push({
+        x: Array(activeIdx.length).fill(xIdx),
+        y: activeIdx,
+        mode: "markers",
+        marker: { color: "#1f2937", size: 14 },
+        showlegend: false,
+        xaxis: "x",
+        yaxis: "y2",
+        hoverinfo: "none",
+      });
+    });
+
+    const layout = {
+      grid: { rows: 2, columns: 1, pattern: "independent" },
+      margin: { t: 40, l: 100, r: 20, b: 40 },
+      showlegend: false,
+      xaxis: { visible: false, domain: [0, 1] },
+      yaxis: {
+        title: "Intersection Size",
+        domain: [0.4, 1],
+        fixedrange: true,
+      },
+      yaxis2: {
+        title: "Sets",
+        domain: [0, 0.35],
+        tickvals: [0, 1, 2, 3],
+        ticktext: setNames,
+        range: [-0.5, 3.5],
+        autorange: "reversed",
+        fixedrange: true,
+      },
+      plot_bgcolor: "rgba(0,0,0,0)",
+      paper_bgcolor: "rgba(0,0,0,0)",
+      hovermode: "closest",
+    };
+
+    return { data: [traceBar, ...matrixTraces], layout };
+  }
+
+  function buildSummaryVennSpec(stats) {
+    const s = stats || { topOnly: 0, leadOnly: 0, both: 0 };
+    const total = s.topOnly + s.leadOnly + s.both;
+    const getPct = (v) => (total > 0 ? `${((v / total) * 100).toFixed(1)}%` : "0%");
+
+    const traces = [
+      {
+        x: [0, 1],
+        y: [0, 1],
+        mode: "markers",
+        marker: { opacity: 0 },
+        hoverinfo: "none",
+        showlegend: false,
+      },
+    ];
+
+    const layout = {
+      xaxis: { visible: false, range: [0, 1], fixedrange: true },
+      yaxis: { visible: false, range: [0, 1], fixedrange: true },
+      margin: { t: 30, l: 10, r: 10, b: 10 },
+      plot_bgcolor: "rgba(0,0,0,0)",
+      paper_bgcolor: "rgba(0,0,0,0)",
+      shapes: [
+        {
+          type: "circle",
+          xref: "x",
+          yref: "y",
+          x0: 0.15,
+          y0: 0.1,
+          x1: 0.65,
+          y1: 0.85,
+          fillcolor: "rgba(147, 51, 234, 0.3)",
+          line: { color: "#9333ea", width: 2 },
+        },
+        {
+          type: "circle",
+          xref: "x",
+          yref: "y",
+          x0: 0.35,
+          y0: 0.1,
+          x1: 0.85,
+          y1: 0.85,
+          fillcolor: "rgba(56, 189, 248, 0.3)",
+          line: { color: "#38bdf8", width: 2 },
+        },
+      ],
+      annotations: [
+        { x: 0.25, y: 0.95, text: "<b>Top</b>", showarrow: false, font: { size: 16, color: "#7e22ce" } },
+        { x: 0.75, y: 0.95, text: "<b>Lead</b>", showarrow: false, font: { size: 16, color: "#38bdf8" } },
+        { x: 0.25, y: 0.48, text: `<b>${s.topOnly}</b><br>(${getPct(s.topOnly)})`, showarrow: false, font: { size: 14 } },
+        { x: 0.75, y: 0.48, text: `<b>${s.leadOnly}</b><br>(${getPct(s.leadOnly)})`, showarrow: false, font: { size: 14, color: "#38bdf8" } },
+        { x: 0.5, y: 0.48, text: `<b>${s.both}</b><br>(${getPct(s.both)})`, showarrow: false, font: { size: 14, color: "#111827" } },
+      ],
+    };
+
+    return { data: traces, layout, empty: total === 0 };
+  }
+
+  function buildSummaryProbDistSpec(rows) {
+    const buildTrace = (roleFilter, name, color) => {
+      const filtered = (rows || []).filter((d) => d.role === roleFilter);
+      if (filtered.length === 0) return null;
+      return {
+        y: filtered.map((d) => d.rawProb),
+        text: filtered.map(
+          (d) =>
+            `<b>${d.name}</b><br>Role: ${d.role}<br>Clump: ${d.clump}<br>Prob: ${d.prob}<br>Sig: ${d.significance}`,
+        ),
+        type: "box",
+        name,
+        marker: { color },
+        boxpoints: "all",
+        jitter: 0.3,
+        pointpos: -1.8,
+        hoverinfo: "y+text",
+      };
+    };
+
+    const traces = [
+      buildTrace("🏆 Top", "Top Only", "#9333ea"),
+      buildTrace("⭐ Lead", "Lead Only", "#38bdf8"),
+      buildTrace("🏆 Top & ⭐ Lead", "Both", "#111827"),
+    ].filter((t) => t !== null);
+
+    const layout = {
+      margin: { t: 20, l: 40, r: 20, b: 30 },
+      yaxis: { title: "Probability", range: [-0.05, 1.05] },
+      showlegend: false,
+      plot_bgcolor: "rgba(0,0,0,0)",
+      paper_bgcolor: "rgba(0,0,0,0)",
+    };
+
+    return { data: traces, layout, empty: traces.length === 0 };
+  }
+
+  function buildSummaryDistanceSpec(distances) {
+    if (!distances || distances.length === 0) {
+      return {
+        data: [],
+        layout: {
+          margin: { t: 20, l: 60, r: 20, b: 30 },
+          plot_bgcolor: "rgba(0,0,0,0)",
+          paper_bgcolor: "rgba(0,0,0,0)",
+        },
+        empty: true,
+      };
+    }
+
+    const yVals = distances.map((d) => d.dist);
+    const textVals = distances.map(
+      (d) =>
+        `<b>Variant:</b> ${d.variant}<br><b>Gene:</b> ${d.gene}<br><b>Distance:</b> ${d.dist.toLocaleString()} BP`,
+    );
+
+    const traces = [
+      {
+        y: yVals,
+        text: textVals,
+        type: "box",
+        name: "Nearest Gene",
+        marker: { color: "#059669" },
+        boxpoints: "all",
+        jitter: 0.3,
+        pointpos: -1.8,
+        hoverinfo: "y+text",
+      },
+    ];
+
+    const layout = {
+      margin: { t: 20, l: 60, r: 20, b: 30 },
+      yaxis: { title: "Distance (BP)", autorange: true },
+      showlegend: false,
+      plot_bgcolor: "rgba(0,0,0,0)",
+      paper_bgcolor: "rgba(0,0,0,0)",
+    };
+
+    return { data: traces, layout };
+  }
+
+  function buildSummaryLeadDistanceSpec(leadDistances) {
+    if (!leadDistances || leadDistances.length === 0) {
+      return {
+        data: [],
+        layout: {
+          margin: { t: 20, l: 60, r: 20, b: 30 },
+          plot_bgcolor: "rgba(0,0,0,0)",
+          paper_bgcolor: "rgba(0,0,0,0)",
+        },
+        empty: true,
+      };
+    }
+
+    const yVals = leadDistances.map((d) => d.dist);
+    const textVals = leadDistances.map(
+      (d) =>
+        `<b>Chr:</b> ${d.chr}<br><b>Variant 1:</b> ${d.v1}<br><b>Variant 2:</b> ${d.v2}<br><b>Distance:</b> ${d.dist.toLocaleString()} BP`,
+    );
+
+    const traces = [
+      {
+        y: yVals,
+        text: textVals,
+        type: "box",
+        name: "Lead-to-Lead",
+        marker: { color: "#eab308" },
+        boxpoints: "all",
+        jitter: 0.3,
+        pointpos: -1.8,
+        hoverinfo: "y+text",
+      },
+    ];
+
+    const layout = {
+      margin: { t: 20, l: 60, r: 20, b: 30 },
+      yaxis: { title: "Distance (BP)", autorange: true },
+      showlegend: false,
+      plot_bgcolor: "rgba(0,0,0,0)",
+      paper_bgcolor: "rgba(0,0,0,0)",
+    };
+
+    return { data: traces, layout };
+  }
+
   return {
     buildGenesScatterSpec,
     buildVariantsScatterSpec,
     buildLogIterHistogramSpec,
     buildLogPreprocessBarSpec,
     buildLogPreprocessByStepSpec,
+    buildSummaryUpsetSpec,
+    buildSummaryVennSpec,
+    buildSummaryProbDistSpec,
+    buildSummaryDistanceSpec,
+    buildSummaryLeadDistanceSpec,
   };
 }

--- a/frontend/composables/useFalconPlots.js
+++ b/frontend/composables/useFalconPlots.js
@@ -135,13 +135,22 @@ export function useFalconPlots(store) {
       });
     }
 
+    // The CLUMP ID legend is only useful while it stays compact. Once the
+    // dataset has more clumps than will visually fit alongside the plot
+    // (~25), Plotly's external legend column eats most of the horizontal
+    // space and makes the scatter unreadable. Hide it past that threshold;
+    // the per-trace name is still in hover text + the data table.
+    const LEGEND_TRACE_LIMIT = 25;
+    const showLegend = traces.length <= LEGEND_TRACE_LIMIT;
     const layout = {
       xaxis: { title: "PROBABILITY" },
       yaxis: { title: "Negative Log10(P-Value)" },
       hovermode: "closest",
-      margin: { t: 30, l: 60, r: 20, b: 50 },
-      showlegend: true,
-      legend: {
+      margin: { t: 30, l: 60, r: showLegend ? 20 : 30, b: 50 },
+      showlegend: showLegend,
+    };
+    if (showLegend) {
+      layout.legend = {
         title: { text: "CLUMP ID" },
         x: 1.02,
         y: 1,
@@ -150,8 +159,8 @@ export function useFalconPlots(store) {
         bgcolor: "rgba(255,255,255,0.8)",
         bordercolor: "#d1d5db",
         borderwidth: 1,
-      },
-    };
+      };
+    }
     return { data: traces, layout };
   }
 

--- a/frontend/composables/useFalconSummary.js
+++ b/frontend/composables/useFalconSummary.js
@@ -4,6 +4,11 @@
 // variants. Preserves original quirk: strict-filter toggle does NOT affect
 // this output (see spec §11).
 import { useFalconFilters } from "~/composables/useFalconFilters";
+import { getColorForClump } from "~/utils/falcon/colorPalette";
+
+const ROLE_TOP = "🏆 Top";
+const ROLE_LEAD = "⭐ Lead";
+const ROLE_BOTH = "🏆 Top & ⭐ Lead";
 
 export function useFalconSummary(store) {
   const { getNegP, normalizedClumpId } = useFalconFilters(store);
@@ -99,5 +104,191 @@ export function useFalconSummary(store) {
     });
   }
 
-  return { computeTopAndLeadSignals, attachClinicalTrials, attachNoveltyFlags };
+  // ---------------------------------------------------------------------
+  // Plot-shaped rows (matches SummaryModule.processDataset in original
+  // PEGS app.js:749-845). Each row has
+  //   { clump, color, name, prob, rawProb, rawSig, significance, role,
+  //     hasClinicalTrials, clinicalTrials, isNovel }
+  // plus `stats = { topOnly, leadOnly, both }` returned alongside.
+  // ---------------------------------------------------------------------
+  function computeSummaryRowsForPlots(name /* 'genes' | 'variants' */) {
+    const dataset = store.datasets[name];
+    if (!dataset || !dataset.isLoaded) {
+      return { results: [], stats: { topOnly: 0, leadOnly: 0, both: 0 } };
+    }
+
+    const data = dataset.data;
+    const isVariants = name === "variants";
+    const keyName = isVariants ? "VARIANT" : "GENE";
+    const keyLead = isVariants ? "LEAD_SNP" : "NEAREST_TO_LEAD";
+    const keyNegP = isVariants ? "P_VALUE" : "NEG_LOG_P";
+
+    // Pass 1: STRICT top-per-clump (prob >= 0.05 AND negP >= 1).
+    const topPerClump = new Map();
+    data.forEach((row, idx) => {
+      const prob = parseFloat(row["PROBABILITY"]);
+      const negP = getNegP(row, isVariants);
+      if (isNaN(prob) || prob < 0.05) return;
+      if (isNaN(negP) || negP < 1) return;
+      const clumpId = row["CLUMP"] ? row["CLUMP"].toString().trim() : "Unassigned";
+      if (!topPerClump.has(clumpId) || prob > topPerClump.get(clumpId).prob) {
+        topPerClump.set(clumpId, { index: idx, prob });
+      }
+    });
+
+    // Pass 2: emit flat rows under the user's global filter.
+    const results = [];
+    const stats = { topOnly: 0, leadOnly: 0, both: 0 };
+
+    data.forEach((row, idx) => {
+      const prob = parseFloat(row["PROBABILITY"]);
+      const negP = getNegP(row, isVariants);
+      if (store.globalFilter.active) {
+        if (isNaN(prob) || prob < store.globalFilter.minProb) return;
+        if (isNaN(negP) || negP < store.globalFilter.minNegP) return;
+      }
+
+      const clumpId = row["CLUMP"] ? row["CLUMP"].toString().trim() : "Unassigned";
+      const isTop = topPerClump.get(clumpId)?.index === idx;
+      const leadRaw = String(row[keyLead] || "").toLowerCase().trim();
+      const isLead = leadRaw === "true" || leadRaw === "1" || leadRaw === "yes";
+      if (!isTop && !isLead) return;
+
+      let role;
+      if (isTop && isLead) {
+        role = ROLE_BOTH;
+        stats.both++;
+      } else if (isTop) {
+        role = ROLE_TOP;
+        stats.topOnly++;
+      } else {
+        role = ROLE_LEAD;
+        stats.leadOnly++;
+      }
+
+      const rawSig = parseFloat(row[keyNegP]);
+      const formattedSig = isVariants
+        ? rawSig === 0
+          ? "0.0"
+          : isNaN(rawSig)
+            ? ""
+            : rawSig.toExponential(2)
+        : isNaN(rawSig)
+          ? ""
+          : rawSig.toFixed(2);
+
+      const itemName = row[keyName] || row["RSID"] || row["SNP"] || "Unknown";
+      const trials = !isVariants && store.clinicalTrials.isLoaded
+        ? store.clinicalTrials.byGene[itemName?.toUpperCase?.()] || []
+        : [];
+
+      results.push({
+        clump: clumpId,
+        color: getColorForClump(store.caches.clumpColor, clumpId),
+        name: itemName,
+        prob: prob.toFixed(4),
+        rawProb: prob,
+        rawSig,
+        significance: formattedSig,
+        role,
+        hasClinicalTrials: trials.length > 0,
+        clinicalTrials: trials,
+        isNovel: null,
+      });
+    });
+
+    return { results, stats };
+  }
+
+  function computeOverlapStats(name) {
+    return computeSummaryRowsForPlots(name).stats;
+  }
+
+  // ---------------------------------------------------------------------
+  // Replicates the PEGS "Distance Data Extraction" block (app.js:853-921).
+  // Returns { distances, leadDistances }:
+  //   distances = [{ dist, gene, variant }]
+  //   leadDistances = [{ dist, chr, v1, v2 }]
+  // ---------------------------------------------------------------------
+  function computeDistances() {
+    const distances = [];
+    const leadDistances = [];
+    if (!store.datasets.genes.isLoaded || !store.datasets.variants.isLoaded) {
+      return { distances, leadDistances };
+    }
+
+    const rawGenes = store.datasets.genes.data;
+    const rawVariants = store.datasets.variants.data;
+
+    const leadGenes = new Set();
+    rawGenes.forEach((row) => {
+      const leadVal = String(row["NEAREST_TO_LEAD"] || "").toLowerCase().trim();
+      if (leadVal === "true" || leadVal === "1" || leadVal === "yes") {
+        const gName = row["GENE"] || row["ID"];
+        if (gName) leadGenes.add(gName);
+      }
+    });
+
+    const leadsByChr = {};
+
+    rawVariants.forEach((row) => {
+      const leadRaw = String(row["LEAD_SNP"] || "").toLowerCase().trim();
+      const isLead = leadRaw === "true" || leadRaw === "1" || leadRaw === "yes";
+      if (!isLead) return;
+
+      // Distance to nearest gene.
+      const nearestGene = row["NEAREST_GENE"];
+      if (nearestGene && leadGenes.has(nearestGene)) {
+        const distStr = row["NEAREST_DISTANCE"];
+        if (distStr !== undefined && distStr !== "") {
+          const dist = parseFloat(distStr);
+          if (!isNaN(dist)) {
+            distances.push({
+              dist: Math.abs(dist),
+              gene: nearestGene,
+              variant: row["VARIANT"] || row["RSID"] || row["SNP"] || "Unknown",
+            });
+          }
+        }
+      }
+
+      // Collect leads grouped by chromosome.
+      const chr = row["CHR"] != null ? String(row["CHR"]).trim() : "";
+      const posStr = row["POS"];
+      if (chr && posStr !== undefined && posStr !== "") {
+        const pos = parseInt(posStr, 10);
+        if (!isNaN(pos)) {
+          if (!leadsByChr[chr]) leadsByChr[chr] = [];
+          leadsByChr[chr].push({
+            pos,
+            variant: row["VARIANT"] || row["RSID"] || row["SNP"] || "Unknown",
+          });
+        }
+      }
+    });
+
+    Object.keys(leadsByChr).forEach((chr) => {
+      const leads = leadsByChr[chr].sort((a, b) => a.pos - b.pos);
+      for (let i = 1; i < leads.length; i++) {
+        const dist = leads[i].pos - leads[i - 1].pos;
+        leadDistances.push({
+          dist,
+          chr,
+          v1: leads[i - 1].variant,
+          v2: leads[i].variant,
+        });
+      }
+    });
+
+    return { distances, leadDistances };
+  }
+
+  return {
+    computeTopAndLeadSignals,
+    attachClinicalTrials,
+    attachNoveltyFlags,
+    computeSummaryRowsForPlots,
+    computeOverlapStats,
+    computeDistances,
+  };
 }

--- a/frontend/composables/useGeneTraitFetcher.js
+++ b/frontend/composables/useGeneTraitFetcher.js
@@ -12,52 +12,131 @@ const TRAIT_URL_BASE =
   "https://api.codetabs.com/v1/proxy?quest=" +
   encodeURIComponent("https://hugeampkpncms.org/rest/egls?gene=");
 
+// Module-scope cache so calling useGeneTraitFetcher() again reuses the
+// loaded catalog (matches the original's GeneTraitFetcher singleton).
+const catalogByPageId = {};
+let catalogReady = false;
+let catalogPromise = null;
+
 export function useGeneTraitFetcher(store) {
+
   async function fetchCatalog(signal) {
-    const res = await fetch(CATALOG_URL, { signal });
-    if (!res.ok) throw new Error(`catalog fetch: HTTP ${res.status}`);
-    const json = await res.json();
-    const csvText = json.field_data_points;
-    if (typeof csvText !== "string") throw new Error("catalog: unexpected shape");
-    return new Promise((resolve, reject) => {
-      Papa.parse(csvText, {
-        header: true,
-        skipEmptyLines: true,
-        complete: (r) => {
-          r.data.forEach((row) => {
-            const g = (row.Gene || "").toUpperCase().trim();
-            if (!g) return;
-            if (!store.caches.traitLookup[g]) store.caches.traitLookup[g] = [];
-            store.caches.traitLookup[g].push(row);
-          });
-          resolve();
-        },
-        error: (err) => reject(err),
+    if (catalogReady) return;
+    if (catalogPromise) return catalogPromise;
+
+    catalogPromise = (async () => {
+      const res = await fetch(CATALOG_URL, { signal });
+      if (!res.ok) throw new Error(`catalog fetch: HTTP ${res.status}`);
+      const json = await res.json();
+      // The HuGEAMP endpoint returns an array; PEGS app.js:1776 uses json[0].
+      // Be permissive in case the proxy ever flattens to a bare object.
+      const root = Array.isArray(json) ? json[0] : json;
+      const csvText = root && root.field_data_points;
+      if (typeof csvText !== "string") {
+        throw new Error("catalog: unexpected shape (no field_data_points)");
+      }
+      await new Promise((resolve, reject) => {
+        Papa.parse(csvText, {
+          header: true,
+          skipEmptyLines: true,
+          complete: (r) => {
+            r.data.forEach((row) => {
+              const pageId = row["Page ID"];
+              if (pageId) catalogByPageId[pageId] = row;
+            });
+            resolve();
+          },
+          error: (err) => reject(err),
+        });
       });
+      catalogReady = true;
+    })().finally(() => {
+      catalogPromise = null;
     });
+    return catalogPromise;
   }
 
   async function fetchTraits(geneNames, signal) {
+    // Make sure the master catalog is loaded once before any per-gene fetch.
+    if (!catalogReady) {
+      try {
+        await fetchCatalog(signal);
+      } catch (err) {
+        if (err.name === "AbortError") throw err;
+        // Without a catalog we can't translate page IDs to traits, so
+        // mark every requested gene as having no traits and bail out.
+        console.error("[useGeneTraitFetcher] catalog load failed:", err);
+        geneNames.forEach((g) => {
+          const key = (g || "").toUpperCase().trim();
+          if (key && !store.caches.traitLookup[key]) {
+            store.caches.traitLookup[key] = [];
+          }
+        });
+        return;
+      }
+    }
+
     const unique = Array.from(
       new Set(geneNames.map((g) => g.toUpperCase().trim()).filter(Boolean)),
     );
     const todo = unique.filter((g) => !store.caches.traitLookup[g]);
-    await Promise.all(
-      todo.map(async (g) => {
-        try {
-          const res = await fetch(TRAIT_URL_BASE + encodeURIComponent(g), { signal });
-          if (!res.ok) {
-            store.caches.traitLookup[g] = [];
-            return;
-          }
-          const json = await res.json();
-          store.caches.traitLookup[g] = Array.isArray(json) ? json : json?.data || [];
-        } catch (err) {
-          if (err.name === "AbortError") throw err;
+
+    // Throttled worker pool — Chrome rejects unbounded parallel fetches with
+    // ERR_INSUFFICIENT_RESOURCES once you push past a few hundred. The
+    // codetabs proxy is also rate-limited; CONCURRENCY=8 is conservative.
+    const CONCURRENCY = 8;
+    let i = 0;
+
+    async function fetchOne(g) {
+      try {
+        const res = await fetch(TRAIT_URL_BASE + encodeURIComponent(g), {
+          signal,
+        });
+        if (!res.ok) {
           store.caches.traitLookup[g] = [];
+          return;
         }
-      }),
-    );
+        const json = await res.json();
+        // The egls endpoint returns an array of { field_page_id, ... }.
+        // For each, look up the catalog row to materialise a trait record.
+        const items = Array.isArray(json) ? json : json?.data || [];
+        const traits = [];
+        items.forEach((item) => {
+          const pageId = item && (item.field_page_id || item["Page ID"]);
+          const rowData = pageId ? catalogByPageId[pageId] : null;
+          if (rowData) {
+            traits.push({
+              page_id: pageId,
+              trait: rowData["Trait"] || "N/A",
+              pmid: rowData["PMID"] || "N/A",
+              citation: rowData["Citation"] || "N/A",
+              authors: rowData["short_name"] || "N/A",
+            });
+          }
+        });
+        store.caches.traitLookup[g] = traits;
+      } catch (err) {
+        if (err.name === "AbortError") throw err;
+        // Don't log every failure; log summary at end. Treat as no-traits so
+        // the user still sees deterministic behaviour.
+        store.caches.traitLookup[g] = [];
+      }
+    }
+
+    async function worker() {
+      while (i < todo.length) {
+        if (signal && signal.aborted) {
+          const e = new Error("Aborted");
+          e.name = "AbortError";
+          throw e;
+        }
+        const g = todo[i++];
+        await fetchOne(g);
+      }
+    }
+
+    const workers = Array.from({ length: Math.min(CONCURRENCY, todo.length) }, () => worker());
+    await Promise.all(workers);
   }
 
   return { fetchCatalog, fetchTraits };

--- a/frontend/composables/usePlotly.js
+++ b/frontend/composables/usePlotly.js
@@ -16,6 +16,17 @@ export function usePlotly() {
     const Plotly = await loadPlotly();
     const config = { responsive: true, displaylogo: false, ...(spec.config || {}) };
     await Plotly.newPlot(el, spec.data, spec.layout, config);
+    // PrimeVue Tabs lazy-mounts panels: when our plot first paints, the
+    // host is display:none, so Plotly latches a 0-width canvas. After the
+    // next animation frame the panel has its real dimensions; nudge Plotly
+    // to recompute. Fixes "Genes Plot / Variants Plot squished to the left".
+    requestAnimationFrame(() => {
+      try {
+        if (el && el.offsetParent !== null) Plotly.Plots.resize(el);
+      } catch {
+        // best-effort resize; safe to swallow if Plotly disposed the element.
+      }
+    });
     return el;
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #30. The original merge of PR #30 happened before the bug-fix and Summary-plot commits were pushed to `falcon-variant-a` — only the foundation work landed in `main`. This PR brings in the missing commits.

**Commits on this branch not yet in `main`:**

```
4f1e02d feat(falcon-a): restore Executive Summary plots
11a1f3c fix(falcon-a): add Pre-process Times section and reformat total time
2d1add1 fix(falcon-a): repair novelty fetcher (catalog shape + parallel limit)
cb6f437 fix(falcon-a): restore per-section search and role filter on Executive Summary
5d744de fix(falcon-a): repair LD Matrix layout and restore plotly_click inspector
1b8e732 fix(falcon-a): cap scatter legend when clump count exceeds threshold
8dbef22 fix(falcon-a): resize scatter plots after lazy tab mount
```

These address the user feedback summarized below.

## What gets fixed

- **Tab Layout (Genes/Variants squished)** — scatter legend hidden when clump count > 25; otherwise it ate ~50% of the plot width.
- **LD Matrix slider overlap** — Min R² and Max Stretch now in separate columns.
- **Executive Summary filters missing** — per-section search input + role filter (top/lead/both) + paginator restored.
- **Novelty function broken** — fixed two real bugs: (a) catalog response shape was \`[ {field_data_points: csv} ]\` but code read \`json.field_data_points\` (missing \`[0]\`); (b) firing 1300+ parallel \`fetch()\`s tripped Chrome's \`ERR_INSUFFICIENT_RESOURCES\`. Now: correct shape + 8-way concurrency limit.
- **FALCON Zoom clipboard lost** — \`plotly_click\` → DataInspectorPanel inject wiring restored.
- **Execution Time formatting** — Total Execution Time now shows \"1h 42m 29.27s (6149.27s)\".
- **Pre-process Times section missing** — new \"Pre-process Steps Accumulation Time\" card lists all 12 steps from \`PRE_PROCESS_KEYS\` with per-step seconds; per-chromosome max sums when chrView=all.
- **All Executive Summary plots missing** — six plots restored (UpSet, Venn, Probability box-plots × 2, Distance, Lead-Distance) lifted from PEGS \`SummaryModule\`.

## Test plan

- [ ] Visit \`/falcon-a\`; load fixture (e.g. T2D)
- [ ] Executive Summary: 6 plots render at top; per-section search + role filter + paginator work
- [ ] Genes/Variants Plot: scatters render full-width (legend hidden for >25 clumps)
- [ ] Data Table: paginated, sortable
- [ ] FALCON Zoom: Run Analysis renders plot; click a point opens inspector
- [ ] Execution Time: total time formatted; Pre-process Steps Accumulation Time card present; per-chromosome bar
- [ ] Novelty toggle: completes without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)