### PR TITLE
fix(falcon-b): bug fixes + restore Executive Summary plots (missed by #31)

### DIFF
--- a/frontend/components/falcon-b/ExecutiveSummaryTab.vue
+++ b/frontend/components/falcon-b/ExecutiveSummaryTab.vue
@@ -1,5 +1,86 @@
 <template>
   <div>
+    <!-- ─── Executive Summary plots (row 1: upset + venn) ─── -->
+    <div class="plot-row plot-row--two">
+      <div class="plot-card">
+        <h4>🧬 Gene Intersection: Top, Lead, and Novel</h4>
+        <p class="plot-desc">
+          <strong>Top Genes</strong> are highest probability targets.
+          <strong>Lead Genes</strong> are physically nearest.
+          <strong>Novel Genes</strong> have no previous associations in our catalog.
+          <strong>Clinical Trials</strong> indicates genes with known clinical data.
+        </p>
+        <div class="plot-mount plot-mount--upset">
+          <div ref="upsetEl" class="plot-inner" />
+          <div v-if="upsetSpec?.empty" class="plot-empty">No intersection data.</div>
+        </div>
+      </div>
+
+      <div class="plot-card">
+        <h4>🔬 Variant Overlap: Top vs. Lead</h4>
+        <p class="plot-desc">
+          <strong>Top Variants</strong> are the variants with the highest FALCON probability in their clump.
+          <strong>Lead Variants</strong> represent the index signal of the clump.
+          This diagram shows how often the model's top variant matches the original index signal.
+        </p>
+        <div class="plot-mount plot-mount--venn">
+          <div ref="vennEl" class="plot-inner" />
+        </div>
+      </div>
+    </div>
+
+    <!-- ─── row 2: probability distributions ─── -->
+    <div class="plot-row plot-row--two">
+      <div class="plot-card">
+        <h4>📊 Gene Probability Distribution</h4>
+        <p class="plot-desc">
+          Distribution of FALCON probabilities across the Top, Lead, and Concordant gene categories.
+        </p>
+        <div class="plot-mount plot-mount--dist">
+          <div ref="probGenesEl" class="plot-inner" />
+          <div v-if="probGenesSpec?.empty" class="plot-empty">No gene probability data.</div>
+        </div>
+      </div>
+
+      <div class="plot-card">
+        <h4>📊 Variant Probability Distribution</h4>
+        <p class="plot-desc">
+          Distribution of FALCON probabilities across the Top, Lead, and Concordant variant categories.
+        </p>
+        <div class="plot-mount plot-mount--dist">
+          <div ref="probVariantsEl" class="plot-inner" />
+          <div v-if="probVariantsSpec?.empty" class="plot-empty">No variant probability data.</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ─── row 3: distance plots ─── -->
+    <div class="plot-row plot-row--two">
+      <div class="plot-card">
+        <h4>📏 Distance to Nearest Gene</h4>
+        <p class="plot-desc">
+          Physical distance (BP) from the <strong>Index Variant</strong> to its designated <strong>Lead Gene</strong>.
+        </p>
+        <div class="plot-mount plot-mount--dist">
+          <div ref="distEl" class="plot-inner" />
+          <div v-if="distSpec?.empty" class="plot-empty">No distance data available.</div>
+        </div>
+      </div>
+
+      <div class="plot-card">
+        <h4>📏 Distance Between Lead Variants</h4>
+        <p class="plot-desc">
+          Physical distance (BP) between adjacent <strong>Index Variants</strong> across the same chromosome.
+        </p>
+        <div class="plot-mount plot-mount--dist">
+          <div ref="leadDistEl" class="plot-inner" />
+          <div v-if="leadDistSpec?.empty" class="plot-empty">
+            Not enough adjacent lead variants available to measure distances.
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div class="summary-toolbar">
       <button
         class="summary-btn"
@@ -57,14 +138,29 @@
 </template>
 
 <script setup>
-import { computed, h, ref, watch } from 'vue';
+import { computed, h, onBeforeUnmount, ref, watch, watchEffect } from 'vue';
 import { useFalconStore } from '~/stores/FalconStore';
 import { useFalconSummary } from '~/composables/useFalconSummary';
+import { useFalconPlots } from '~/composables/useFalconPlots';
+import { usePlotly } from '~/composables/usePlotly';
 import TraitCard from '~/components/falcon-b/TraitCard.vue';
 
 const store = useFalconStore();
-const { computeTopAndLeadSignals, attachClinicalTrials, attachNoveltyFlags } =
-  useFalconSummary(store);
+const {
+  computeTopAndLeadSignals,
+  attachClinicalTrials,
+  attachNoveltyFlags,
+  computeSummaryRowsForPlots,
+  computeDistances,
+} = useFalconSummary(store);
+const {
+  buildSummaryUpsetSpec,
+  buildSummaryVennSpec,
+  buildSummaryProbDistSpec,
+  buildSummaryDistanceSpec,
+  buildSummaryLeadDistanceSpec,
+} = useFalconPlots(store);
+const { mount, unmount } = usePlotly();
 
 const clinicalTrials = store.clinicalTrials;
 const summary = ref({
@@ -76,11 +172,35 @@ const noveltyLoading = ref(false);
 const noveltyError = ref(false);
 let abortCtrl = null;
 
+// Plot-shaped summary data and refs.
+const genesPlotRows = ref([]);
+const variantsPlotRows = ref([]);
+const variantsStats = ref({ topOnly: 0, leadOnly: 0, both: 0 });
+const distances = ref([]);
+const leadDistances = ref([]);
+
+const upsetEl = ref(null);
+const vennEl = ref(null);
+const probGenesEl = ref(null);
+const probVariantsEl = ref(null);
+const distEl = ref(null);
+const leadDistEl = ref(null);
+
+const upsetSpec = computed(() => buildSummaryUpsetSpec(genesPlotRows.value));
+const vennSpec = computed(() => buildSummaryVennSpec(variantsStats.value));
+const probGenesSpec = computed(() => buildSummaryProbDistSpec(genesPlotRows.value));
+const probVariantsSpec = computed(() => buildSummaryProbDistSpec(variantsPlotRows.value));
+const distSpec = computed(() => buildSummaryDistanceSpec(distances.value));
+const leadDistSpec = computed(() => buildSummaryLeadDistanceSpec(leadDistances.value));
+
 watch(
   () => [
     store.datasets.genes.isLoaded,
     store.datasets.variants.isLoaded,
     clinicalTrials.isLoaded,
+    store.globalFilter.active,
+    store.globalFilter.minProb,
+    store.globalFilter.minNegP,
   ],
   recompute,
   { immediate: true },
@@ -93,7 +213,35 @@ function recompute() {
     attachClinicalTrials(s.variants[k]);
   });
   summary.value = s;
+
+  const genes = computeSummaryRowsForPlots('genes');
+  const variants = computeSummaryRowsForPlots('variants');
+  genesPlotRows.value = genes.results;
+  variantsPlotRows.value = variants.results;
+  variantsStats.value = variants.stats;
+
+  const d = computeDistances();
+  distances.value = d.distances;
+  leadDistances.value = d.leadDistances;
 }
+
+function mountPlot(el, spec) {
+  if (!el || !spec) return;
+  mount(el, spec);
+}
+
+watchEffect(() => { mountPlot(upsetEl.value, upsetSpec.value); });
+watchEffect(() => { mountPlot(vennEl.value, vennSpec.value); });
+watchEffect(() => { mountPlot(probGenesEl.value, probGenesSpec.value); });
+watchEffect(() => { mountPlot(probVariantsEl.value, probVariantsSpec.value); });
+watchEffect(() => { mountPlot(distEl.value, distSpec.value); });
+watchEffect(() => { mountPlot(leadDistEl.value, leadDistSpec.value); });
+
+onBeforeUnmount(async () => {
+  for (const el of [upsetEl, vennEl, probGenesEl, probVariantsEl, distEl, leadDistEl]) {
+    if (el.value) await unmount(el.value);
+  }
+});
 
 async function toggleNovelty() {
   // If we are turning OFF, just flip the flag — don't touch cached traits.
@@ -288,6 +436,63 @@ const SummarySection = {
 </script>
 
 <style scoped>
+.plot-row {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+}
+.plot-row--two > .plot-card {
+  flex: 1;
+  min-width: 300px;
+}
+.plot-card {
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+.plot-card h4 {
+  margin-top: 0;
+  margin-bottom: 8px;
+  padding-bottom: 8px;
+  color: #111827;
+  font-size: 1.1em;
+  border-bottom: 2px solid #e5e7eb;
+}
+.plot-desc {
+  font-size: 0.9em;
+  color: #4b5563;
+  line-height: 1.5;
+  margin-bottom: 10px;
+  margin-top: 0;
+}
+.plot-mount {
+  position: relative;
+  width: 100%;
+}
+.plot-mount--upset { height: 350px; }
+.plot-mount--venn  { height: 280px; }
+.plot-mount--dist  { height: 260px; }
+.plot-inner {
+  width: 100%;
+  height: 100%;
+}
+.plot-empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #6b7280;
+  font-style: italic;
+  pointer-events: none;
+  font-size: 0.9em;
+  text-align: center;
+  padding: 0 10px;
+}
+
 .summary-toolbar {
   display: flex;
   gap: 10px;

--- a/frontend/components/falcon-b/ExecutiveSummaryTab.vue
+++ b/frontend/components/falcon-b/ExecutiveSummaryTab.vue
@@ -8,9 +8,22 @@
       >
         {{ clinicalTrials.isLoaded ? '✓ Clinical Trials Loaded' : 'Load Clinical Trials CSV' }}
       </button>
-      <button class="summary-btn outline" @click="toggleNovelty">
-        {{ showNovel ? 'Novelty filter: ON' : 'Novelty filter: OFF' }}
+      <button
+        class="summary-btn outline"
+        :disabled="noveltyLoading"
+        @click="toggleNovelty"
+      >
+        {{
+          noveltyLoading
+            ? 'Loading novelty…'
+            : showNovel
+              ? '★ Novelty filter: ON'
+              : '☆ Novelty filter: OFF'
+        }}
       </button>
+      <span v-if="noveltyError" class="novelty-error">
+        Novelty fetch failed — see console.
+      </span>
       <input
         ref="trialsInput"
         type="file"
@@ -20,29 +33,34 @@
       />
     </div>
 
-    <section class="summary-section">
-      <h3>Top Genes per Clump</h3>
-      <TraitCard v-for="row in filteredGenesTop" :key="`g-top-${row.index}`" :row="row" />
-    </section>
-    <section class="summary-section">
-      <h3>Lead Genes per Chromosome</h3>
-      <TraitCard v-for="row in filteredGenesLead" :key="`g-lead-${row.index}`" :row="row" />
-    </section>
-    <section class="summary-section">
-      <h3>Top Variants per Clump</h3>
-      <TraitCard v-for="row in summary.variants?.top || []" :key="`v-top-${row.index}`" :row="row" />
-    </section>
-    <section class="summary-section">
-      <h3>Lead Variants per Chromosome</h3>
-      <TraitCard v-for="row in summary.variants?.lead || []" :key="`v-lead-${row.index}`" :row="row" />
-    </section>
+    <SummarySection
+      title="Top Genes per Clump"
+      :rows="summary.genes?.top || []"
+      :show-novel-filter="showNovel"
+    />
+    <SummarySection
+      title="Lead Genes per Chromosome"
+      :rows="summary.genes?.lead || []"
+      :show-novel-filter="showNovel"
+    />
+    <SummarySection
+      title="Top Variants per Clump"
+      :rows="summary.variants?.top || []"
+      :show-novel-filter="false"
+    />
+    <SummarySection
+      title="Lead Variants per Chromosome"
+      :rows="summary.variants?.lead || []"
+      :show-novel-filter="false"
+    />
   </div>
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue';
+import { computed, h, ref, watch } from 'vue';
 import { useFalconStore } from '~/stores/FalconStore';
 import { useFalconSummary } from '~/composables/useFalconSummary';
+import TraitCard from '~/components/falcon-b/TraitCard.vue';
 
 const store = useFalconStore();
 const { computeTopAndLeadSignals, attachClinicalTrials, attachNoveltyFlags } =
@@ -54,6 +72,8 @@ const summary = ref({
   variants: { top: [], lead: [] },
 });
 const showNovel = ref(false);
+const noveltyLoading = ref(false);
+const noveltyError = ref(false);
 let abortCtrl = null;
 
 watch(
@@ -75,28 +95,31 @@ function recompute() {
   summary.value = s;
 }
 
-const filteredGenesTop = computed(() =>
-  showNovel.value
-    ? (summary.value.genes?.top || []).filter((r) => r.isNovel === true)
-    : summary.value.genes?.top || [],
-);
-const filteredGenesLead = computed(() =>
-  showNovel.value
-    ? (summary.value.genes?.lead || []).filter((r) => r.isNovel === true)
-    : summary.value.genes?.lead || [],
-);
-
 async function toggleNovelty() {
-  showNovel.value = !showNovel.value;
+  // If we are turning OFF, just flip the flag — don't touch cached traits.
   if (showNovel.value) {
-    if (abortCtrl) abortCtrl.abort();
-    abortCtrl = new AbortController();
-    const all = [...summary.value.genes.top, ...summary.value.genes.lead];
-    try {
-      await attachNoveltyFlags(all, abortCtrl.signal);
-    } catch (err) {
-      if (err.name !== 'AbortError') console.error(err);
+    showNovel.value = false;
+    return;
+  }
+  // Turn ON: fetch novelty for every gene row in either gene section.
+  if (abortCtrl) abortCtrl.abort();
+  abortCtrl = new AbortController();
+  noveltyLoading.value = true;
+  noveltyError.value = false;
+  const all = [
+    ...(summary.value.genes.top || []),
+    ...(summary.value.genes.lead || []),
+  ];
+  try {
+    await attachNoveltyFlags(all, abortCtrl.signal);
+    showNovel.value = true;
+  } catch (err) {
+    if (err.name !== 'AbortError') {
+      console.error('[ExecutiveSummaryTab] novelty fetch failed', err);
+      noveltyError.value = true;
     }
+  } finally {
+    noveltyLoading.value = false;
   }
 }
 
@@ -112,6 +135,156 @@ async function onTrialsFile(e) {
     console.error('clinical trials load failed', err);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Inline section component: per-section search + role filter + paginator,
+// porting SummaryModule.buildInteractiveTable filtering UX (PEGS app.js:1421+).
+// Inline rather than a separate file to keep variant-B's blast radius small.
+// Uses native inputs + .page-btn / .search-input styling shared with
+// DataTableTab.vue, preserving the original PEGS dashboard aesthetic.
+// ---------------------------------------------------------------------------
+const ROLE_OPTIONS = [
+  { value: 'all', label: 'All Roles' },
+  { value: 'top', label: 'Top Only' },
+  { value: 'lead', label: 'Lead Only' },
+  { value: 'both', label: 'Top & Lead' },
+];
+
+const SummarySection = {
+  props: {
+    title: { type: String, required: true },
+    rows: { type: Array, required: true },
+    showNovelFilter: { type: Boolean, default: false },
+  },
+  setup(props) {
+    const search = ref('');
+    const roleFilter = ref('all');
+    const page = ref(1);
+    const pageSize = 10;
+
+    // The shape coming out of useFalconSummary doesn't carry an explicit
+    // "role" — top rows live in .top, leads in .lead. The same gene can
+    // appear in both. Detect "both" by treating isLead as the proxy.
+    const filtered = computed(() => {
+      const list = props.rows || [];
+      const q = search.value.trim().toLowerCase();
+      return list.filter((row) => {
+        if (roleFilter.value === 'top' && row.isLead) return false;
+        if (roleFilter.value === 'lead' && !row.isLead) return false;
+        if (roleFilter.value === 'both' && !row.isLead) return false;
+
+        if (props.showNovelFilter) {
+          if (row.isNovel === null || row.isNovel === undefined) return false;
+          if (row.isNovel !== true) return false;
+        }
+
+        if (q) {
+          const hay =
+            `${row.name || ''} ${row.clumpId || ''} ${row.chr || ''}`.toLowerCase();
+          if (!hay.includes(q)) return false;
+        }
+        return true;
+      });
+    });
+
+    const totalPages = computed(() =>
+      Math.max(1, Math.ceil(filtered.value.length / pageSize)),
+    );
+    const pageRows = computed(() => {
+      const start = (page.value - 1) * pageSize;
+      return filtered.value.slice(start, start + pageSize);
+    });
+
+    watch(
+      [search, roleFilter, () => props.rows.length, () => props.showNovelFilter],
+      () => {
+        if (page.value > totalPages.value) page.value = totalPages.value;
+        if (page.value < 1) page.value = 1;
+      },
+    );
+
+    return () =>
+      h('section', { class: 'summary-section' }, [
+        h('div', { class: 'section-header' }, [
+          h('h3', {}, [
+            props.title,
+            h(
+              'span',
+              { class: 'muted' },
+              ` (${filtered.value.length} of ${(props.rows || []).length})`,
+            ),
+          ]),
+          h('div', { class: 'section-controls' }, [
+            h(
+              'select',
+              {
+                class: 'role-select',
+                value: roleFilter.value,
+                onChange: (e) => {
+                  roleFilter.value = e.target.value;
+                  page.value = 1;
+                },
+              },
+              ROLE_OPTIONS.map((o) =>
+                h('option', { value: o.value, key: o.value }, o.label),
+              ),
+            ),
+            h('input', {
+              type: 'text',
+              class: 'search-input search-input--small',
+              placeholder: 'Search name / clump / chr…',
+              value: search.value,
+              onInput: (e) => {
+                search.value = e.target.value;
+                page.value = 1;
+              },
+            }),
+          ]),
+        ]),
+        pageRows.value.length === 0
+          ? h(
+              'div',
+              { class: 'no-rows' },
+              (props.rows || []).length === 0
+                ? 'No data loaded.'
+                : 'No rows match current filters.',
+            )
+          : h(
+              'div',
+              { class: 'section-list' },
+              pageRows.value.map((row, i) =>
+                h(TraitCard, { row, key: `${row.name || 'r'}-${row.index ?? i}` }),
+              ),
+            ),
+        h('div', { class: 'pagination' }, [
+          h(
+            'button',
+            {
+              class: 'page-btn',
+              disabled: page.value <= 1,
+              onClick: () => (page.value = Math.max(1, page.value - 1)),
+            },
+            'Prev',
+          ),
+          h(
+            'span',
+            { class: 'page-info' },
+            `Page ${page.value} of ${totalPages.value}`,
+          ),
+          h(
+            'button',
+            {
+              class: 'page-btn',
+              disabled: page.value >= totalPages.value,
+              onClick: () =>
+                (page.value = Math.min(totalPages.value, page.value + 1)),
+            },
+            'Next',
+          ),
+        ]),
+      ]);
+  },
+};
 </script>
 
 <style scoped>
@@ -120,6 +293,7 @@ async function onTrialsFile(e) {
   gap: 10px;
   margin-bottom: 20px;
   flex-wrap: wrap;
+  align-items: center;
 }
 .summary-btn {
   padding: 8px 14px;
@@ -135,17 +309,83 @@ async function onTrialsFile(e) {
 .summary-btn.primary:hover { background: #2563eb; }
 .summary-btn.success { background: #d1fae5; color: #047857; border-color: #10b981; }
 .summary-btn.outline { background: white; }
-.summary-btn.outline:hover { background: #f3f4f6; }
+.summary-btn.outline:hover:not(:disabled) { background: #f3f4f6; }
+.summary-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.novelty-error { color: #dc2626; font-size: 0.85em; font-weight: 600; }
+
 .summary-section {
   margin-bottom: 28px;
 }
-.summary-section h3 {
-  font-size: 1.05em;
-  font-weight: 700;
-  color: #111827;
-  margin: 0 0 10px 0;
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 10px;
   padding-bottom: 6px;
   border-bottom: 2px solid #3b82f6;
 }
+.section-header h3 {
+  font-size: 1.05em;
+  font-weight: 700;
+  color: #111827;
+  margin: 0;
+}
+.section-header .muted {
+  color: #9ca3af;
+  font-weight: 400;
+  font-size: 0.85em;
+  margin-left: 6px;
+}
+.section-controls {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.role-select {
+  padding: 6px 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: white;
+  font-size: 0.85em;
+  min-width: 130px;
+}
+.search-input {
+  padding: 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  width: 250px;
+  font-size: 0.9em;
+}
+.search-input--small { padding: 6px 8px; width: 220px; font-size: 0.85em; }
+.section-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.no-rows {
+  color: #6b7280;
+  font-style: italic;
+  padding: 12px 4px;
+}
+.pagination {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: flex-end;
+  margin-top: 10px;
+}
+.page-btn {
+  padding: 6px 12px;
+  border: 1px solid #d1d5db;
+  background: white;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.page-btn:hover:not(:disabled) { background: #f3f4f6; }
+.page-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.page-info { color: #6b7280; font-size: 0.85em; }
 .hidden { display: none; }
 </style>

--- a/frontend/components/falcon-b/GenesScatterTab.vue
+++ b/frontend/components/falcon-b/GenesScatterTab.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script setup>
-import { ref, watchEffect, onBeforeUnmount, inject } from 'vue';
+import { ref, watchEffect, onBeforeUnmount, onActivated, onMounted, inject, nextTick } from 'vue';
 import { useFalconStore } from '~/stores/FalconStore';
 import { useFalconPlots } from '~/composables/useFalconPlots';
 import { usePlotly } from '~/composables/usePlotly';
@@ -38,6 +38,21 @@ watchEffect(async () => {
   };
   current.on('plotly_click', clickHandler);
 });
+
+// Re-resize after activation in case the plot was first laid out while the
+// parent tab panel was still display:none.
+async function nudgeResize() {
+  if (!current) return;
+  const Plotly = await getPlotly();
+  await nextTick();
+  try {
+    if (current.offsetParent !== null) Plotly.Plots.resize(current);
+  } catch {
+    // ignore
+  }
+}
+onMounted(nudgeResize);
+onActivated(nudgeResize);
 
 onBeforeUnmount(async () => {
   if (current) await unmount(current);

--- a/frontend/components/falcon-b/LogSummaryTab.vue
+++ b/frontend/components/falcon-b/LogSummaryTab.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="log-header">
       <h3>FALCON Execution Time Summary</h3>
-      <span class="total-time-pill">Total Execution Time: {{ totalTime }}</span>
+      <span class="total-time-pill">Total Execution Time: {{ formattedTotalTime }}</span>
     </div>
 
     <div class="explain-card">
@@ -40,6 +40,23 @@
       </select>
     </div>
 
+    <div class="explain-card preprocess-step-card">
+      <div class="preprocess-step-header">
+        <h4>Pre-process Steps Accumulation Time</h4>
+        <span class="total-time-pill small">
+          {{ preProcess.parallel ? 'Total Pre-process (Parallel Wall Time)' : 'Total Pre-process' }}: {{ formatTime(preProcess.totalTime) }}
+        </span>
+      </div>
+      <div class="stats-row preprocess-step-row">
+        <span v-for="step in preProcess.perStep" :key="step.key">
+          <b>{{ step.key }}:</b>
+          <span :class="step.time === 0 ? 'step-zero' : 'step-value'">
+            {{ step.time === 0 ? 'Skipped / 0.00s' : `${step.time.toFixed(2)}s` }}
+          </span>
+        </span>
+      </div>
+    </div>
+
     <div ref="preprocessEl" class="preprocess-bar" />
 
     <div class="hist-grid">
@@ -67,12 +84,31 @@ import { useFalconLogParser } from '~/composables/useFalconLogParser';
 import { usePlotly } from '~/composables/usePlotly';
 
 const store = useFalconStore();
-const { buildLogIterHistogramSpec, buildLogPreprocessBarSpec } =
-  useFalconPlots(store);
-const { ITER_COMPONENTS: components } = useFalconLogParser();
+const {
+  buildLogIterHistogramSpec,
+  buildLogPreprocessBarSpec,
+  buildLogPreprocessByStepSpec,
+} = useFalconPlots(store);
+const { ITER_COMPONENTS: components, PRE_PROCESS_KEYS } = useFalconLogParser();
 const { mount, unmount } = usePlotly();
 
+function formatTime(seconds) {
+  if (!isFinite(seconds) || seconds <= 0) return '0.00s';
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = (seconds % 60).toFixed(2);
+  const parts = [];
+  if (h > 0) parts.push(`${h}h`);
+  if (m > 0 || h > 0) parts.push(`${m}m`);
+  parts.push(`${s}s`);
+  return `${parts.join(' ')} (${seconds.toFixed(2)}s)`;
+}
+
 const chrView = ref('all');
+
+const preProcess = computed(() =>
+  buildLogPreprocessByStepSpec(chrView.value, PRE_PROCESS_KEYS),
+);
 const chrOptions = computed(() => {
   const chrs = Array.from(store.datasets.log.chromosomes).sort((a, b) => {
     const na = parseInt(a, 10), nb = parseInt(b, 10);
@@ -86,6 +122,15 @@ const chrOptions = computed(() => {
 });
 
 const totalTime = computed(() => store.datasets.log.totalTime);
+
+// Reformat the parsed totalTime ("6149.27 seconds") into h/m/s + raw,
+// matching LogSummaryModule.render (PEGS app.js:2531-2548).
+const formattedTotalTime = computed(() => {
+  const raw = parseFloat(totalTime.value);
+  if (isNaN(raw)) return totalTime.value || 'No log file detected.';
+  return formatTime(raw);
+});
+
 const preprocessEl = ref(null);
 const histRefs = ref({});
 const mounted = new Set();
@@ -104,7 +149,7 @@ const compStats = computed(() => {
 
 watchEffect(async () => {
   if (preprocessEl.value) {
-    await mount(preprocessEl.value, buildLogPreprocessBarSpec());
+    await mount(preprocessEl.value, buildLogPreprocessBarSpec(chrView.value));
     mounted.add(preprocessEl.value);
   }
   for (const comp of components) {
@@ -144,6 +189,42 @@ onBeforeUnmount(async () => {
   border-radius: 4px;
   border: 1px solid #10b981;
 }
+.total-time-pill.small {
+  font-size: 0.9em;
+  padding: 4px 10px;
+}
+.preprocess-step-card {
+  padding: 16px 20px;
+}
+.preprocess-step-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.preprocess-step-header h4 { margin: 0; color: #111827; }
+.preprocess-step-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 8px 16px;
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: none;
+  font-size: 0.85em;
+}
+.preprocess-step-row > span {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 8px;
+  border-bottom: 1px dashed #e5e7eb;
+  color: #4b5563;
+}
+.preprocess-step-row b { color: #374151; font-weight: 600; margin-right: 8px; }
+.step-value { color: #047857; font-weight: bold; }
+.step-zero { color: #ef4444; font-weight: normal; }
 .explain-card {
   background: white;
   border: 1px solid #d1d5db;

--- a/frontend/components/falcon-b/TDPTab.vue
+++ b/frontend/components/falcon-b/TDPTab.vue
@@ -32,7 +32,7 @@
 
       <div class="toolbar-divider" />
 
-      <div class="input-group">
+      <div class="input-group ld-group">
         <label class="ld-label">LD Matrix (.gz or .sorted files)</label>
         <div class="ld-row">
           <button class="ld-btn" @click="triggerLdDialog">
@@ -47,25 +47,29 @@
             @change="onLdChange"
           />
           <span class="divider-v" />
-          <label>Min R²</label>
-          <input
-            v-model.number="cfg.minR2"
-            type="number"
-            min="0"
-            max="1"
-            step="0.1"
-            class="mini-input"
-          />
+          <div class="ld-field">
+            <label>Min R²</label>
+            <input
+              v-model.number="cfg.minR2"
+              type="number"
+              min="0"
+              max="1"
+              step="0.1"
+              class="mini-input"
+            />
+          </div>
           <span class="divider-v" />
-          <label>Max Stretch</label>
-          <input
-            v-model.number="cfg.maxStretch"
-            type="range"
-            min="0.1"
-            max="1"
-            step="0.05"
-            class="stretch-range"
-          />
+          <div class="ld-field stretch-field">
+            <label>Max Stretch ({{ cfg.maxStretch.toFixed(2) }})</label>
+            <input
+              v-model.number="cfg.maxStretch"
+              type="range"
+              min="0.1"
+              max="1"
+              step="0.05"
+              class="stretch-range"
+            />
+          </div>
         </div>
       </div>
 
@@ -88,14 +92,15 @@
 </template>
 
 <script setup>
-import { reactive, ref, onBeforeUnmount } from 'vue';
+import { reactive, ref, onBeforeUnmount, inject } from 'vue';
 import { useFalconStore } from '~/stores/FalconStore';
 import { useFalconTDP } from '~/composables/useFalconTDP';
 import { usePlotly } from '~/composables/usePlotly';
 
 const store = useFalconStore();
 const { runAnalysis } = useFalconTDP(store);
-const { mount, unmount } = usePlotly();
+const { mount, unmount, getPlotly } = usePlotly();
+const inspector = inject('falcon-inspector', null);
 
 const cfg = reactive({
   gene: 'CETP',
@@ -110,6 +115,7 @@ const plotEl = ref(null);
 const ldInput = ref(null);
 const running = ref(false);
 let mountedEl = null;
+let clickHandler = null;
 
 async function run() {
   running.value = true;
@@ -118,6 +124,18 @@ async function run() {
     if (!spec || !plotEl.value) return;
     await mount(plotEl.value, spec);
     mountedEl = plotEl.value;
+
+    // Restore InspectorModule.bindToPlot pattern (PEGS app.js:2862-2872):
+    // clicking a point opens the Data Inspector with the point's HTML text.
+    await getPlotly();
+    if (clickHandler) mountedEl.removeAllListeners?.('plotly_click');
+    clickHandler = (ev) => {
+      if (!ev?.points?.length || !inspector?.value) return;
+      const p = ev.points[0];
+      const txt = p.text || p.hovertext || 'No data available for this point.';
+      inspector.value.show(txt);
+    };
+    mountedEl.on('plotly_click', clickHandler);
   } catch (err) {
     console.error('TDP runAnalysis failed:', err);
     store.tdp.status = `Error: ${err.message || String(err)}`;
@@ -182,12 +200,26 @@ onBeforeUnmount(async () => {
   margin: 0 5px;
 }
 .ld-label { color: #2563eb; font-weight: bold; }
+.ld-group { flex: 1 1 auto; min-width: 320px; }
 .ld-row {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
+  row-gap: 8px;
   flex-wrap: wrap;
 }
+.ld-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.ld-field > label {
+  font-size: 0.75em;
+  font-weight: bold;
+  color: #4b5563;
+}
+.stretch-field { min-width: 110px; }
 .ld-btn {
   padding: 6px 12px;
   background: #eff6ff;

--- a/frontend/components/falcon-b/VariantsScatterTab.vue
+++ b/frontend/components/falcon-b/VariantsScatterTab.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script setup>
-import { ref, watchEffect, onBeforeUnmount, inject } from 'vue';
+import { ref, watchEffect, onBeforeUnmount, onActivated, onMounted, inject, nextTick } from 'vue';
 import { useFalconStore } from '~/stores/FalconStore';
 import { useFalconPlots } from '~/composables/useFalconPlots';
 import { usePlotly } from '~/composables/usePlotly';
@@ -37,6 +37,19 @@ watchEffect(async () => {
   };
   current.on('plotly_click', clickHandler);
 });
+
+async function nudgeResize() {
+  if (!current) return;
+  const Plotly = await getPlotly();
+  await nextTick();
+  try {
+    if (current.offsetParent !== null) Plotly.Plots.resize(current);
+  } catch {
+    // ignore
+  }
+}
+onMounted(nudgeResize);
+onActivated(nudgeResize);
 
 onBeforeUnmount(async () => {
   if (current) await unmount(current);

--- a/frontend/composables/useFalconPlots.js
+++ b/frontend/composables/useFalconPlots.js
@@ -227,8 +227,9 @@ export function useFalconPlots(store) {
 
   /**
    * Per-chromosome total pre-process time bar chart.
+   * `chrView` highlights one chromosome in green if not 'all'.
    */
-  function buildLogPreprocessBarSpec() {
+  function buildLogPreprocessBarSpec(chrView /* 'all' | chromosome */) {
     const logStore = store.datasets.log;
     const chrs = Array.from(logStore.chromosomes).sort((a, b) => {
       const na = parseInt(a, 10);
@@ -240,11 +241,13 @@ export function useFalconPlots(store) {
       const pp = logStore.preProcess[chr] || {};
       return Object.values(pp).reduce((a, b) => a + b, 0);
     });
-    const colors = chrs.map((_, i) => FALCON_PALETTE[i % FALCON_PALETTE.length]);
+    const colors = chrs.map((c) =>
+      chrView && chrView !== "all" && chrView === c ? "#047857" : "#3b82f6",
+    );
     return {
       data: [
         {
-          x: chrs,
+          x: chrs.map((c) => `Chr ${c}`),
           y: totals,
           type: "bar",
           marker: { color: colors },
@@ -264,10 +267,58 @@ export function useFalconPlots(store) {
     };
   }
 
+  /**
+   * Pre-process step accumulation summary, mirroring LogSummaryModule.drawPlots
+   * (PEGS app.js:2584-2636).
+   *
+   * For chrView='all': totalTime = parallel-wall-time bottleneck (max chr total),
+   * and per-step values = max value across chromosomes (worst-case worker).
+   * For a specific chromosome: just the values for that chromosome.
+   *
+   * Returns { perStep: [{ key, time }], totalTime, parallel: bool }.
+   */
+  function buildLogPreprocessByStepSpec(chrView /* 'all' | chromosome */, preProcessKeys) {
+    const logStore = store.datasets.log;
+    const perStep = preProcessKeys.map((k) => ({ key: k, time: 0 }));
+    let totalTime = 0;
+    const parallel = chrView === "all";
+
+    if (parallel) {
+      // Wall-time bottleneck = the slowest single chromosome's total.
+      let maxChrTotal = 0;
+      Object.keys(logStore.preProcess).forEach((chr) => {
+        let chrTotal = 0;
+        preProcessKeys.forEach((k) => {
+          chrTotal += logStore.preProcess[chr][k] || 0;
+        });
+        if (chrTotal > maxChrTotal) maxChrTotal = chrTotal;
+      });
+      totalTime = maxChrTotal;
+
+      // Per-step worst case across workers.
+      preProcessKeys.forEach((k, i) => {
+        let maxVal = 0;
+        Object.keys(logStore.preProcess).forEach((chr) => {
+          maxVal = Math.max(maxVal, logStore.preProcess[chr][k] || 0);
+        });
+        perStep[i].time = maxVal;
+      });
+    } else if (logStore.preProcess[chrView]) {
+      preProcessKeys.forEach((k, i) => {
+        const v = logStore.preProcess[chrView][k] || 0;
+        perStep[i].time = v;
+        totalTime += v;
+      });
+    }
+
+    return { perStep, totalTime, parallel };
+  }
+
   return {
     buildGenesScatterSpec,
     buildVariantsScatterSpec,
     buildLogIterHistogramSpec,
     buildLogPreprocessBarSpec,
+    buildLogPreprocessByStepSpec,
   };
 }

--- a/frontend/composables/useFalconPlots.js
+++ b/frontend/composables/useFalconPlots.js
@@ -314,11 +314,332 @@ export function useFalconPlots(store) {
     return { perStep, totalTime, parallel };
   }
 
+  // -------------------------------------------------------------------
+  // Executive Summary plot spec builders.
+  // Ported verbatim from PEGS app.js SummaryModule.drawUpsetPlot (1083-1208),
+  // drawVennDiagram (1210-1234), drawProbDistributionPlot (1236-1273),
+  // drawDistancePlot (1275-1310), drawLeadDistancePlot (1313-1349).
+  // Each returns { data, layout } (plus `empty: true` when nothing to draw).
+  // -------------------------------------------------------------------
+  function buildSummaryUpsetSpec(plotRows) {
+    const setNames = ["Top", "Lead", "Novel", "Clinical Trials"];
+    const combinations = [];
+    for (let i = 1; i < 1 << setNames.length; i++) {
+      const sets = [];
+      for (let j = 0; j < setNames.length; j++) {
+        if ((i >> j) & 1) sets.push(setNames[j]);
+      }
+      combinations.push({ sets, count: 0 });
+    }
+
+    (plotRows || []).forEach((d) => {
+      const flags = {
+        Top: d.role && d.role.includes("Top"),
+        Lead: d.role && d.role.includes("Lead"),
+        Novel: d.isNovel === true,
+        "Clinical Trials": d.hasClinicalTrials === true,
+      };
+      const combo = combinations.find((c) =>
+        setNames.every((s) => flags[s] === c.sets.includes(s)),
+      );
+      if (combo) combo.count++;
+    });
+
+    const plotData = combinations
+      .filter((c) => c.count > 0)
+      .sort((a, b) => b.count - a.count);
+
+    if (plotData.length === 0) {
+      return {
+        data: [],
+        layout: {
+          margin: { t: 40, l: 100, r: 20, b: 40 },
+          plot_bgcolor: "rgba(0,0,0,0)",
+          paper_bgcolor: "rgba(0,0,0,0)",
+        },
+        empty: true,
+      };
+    }
+
+    const xValues = plotData.map((_, i) => i);
+    const barCounts = plotData.map((c) => c.count);
+
+    const traceBar = {
+      x: xValues,
+      y: barCounts,
+      type: "bar",
+      name: "Intersection Size",
+      marker: { color: "#93c5fd" },
+      xaxis: "x",
+      yaxis: "y",
+      hovertemplate: "%{y}<extra></extra>",
+    };
+
+    const matrixTraces = [];
+    setNames.forEach((setName, setIdx) => {
+      matrixTraces.push({
+        x: xValues,
+        y: Array(xValues.length).fill(setIdx),
+        mode: "markers",
+        marker: { color: "#e5e7eb", size: 12 },
+        showlegend: false,
+        xaxis: "x",
+        yaxis: "y2",
+        hoverinfo: "none",
+      });
+    });
+
+    plotData.forEach((combo, xIdx) => {
+      const activeIdx = [];
+      setNames.forEach((setName, setIdx) => {
+        if (combo.sets.includes(setName)) activeIdx.push(setIdx);
+      });
+
+      if (activeIdx.length > 1) {
+        matrixTraces.push({
+          x: [xIdx, xIdx],
+          y: [Math.min(...activeIdx), Math.max(...activeIdx)],
+          mode: "lines",
+          line: { color: "#1f2937", width: 3 },
+          showlegend: false,
+          xaxis: "x",
+          yaxis: "y2",
+          hoverinfo: "none",
+        });
+      }
+
+      matrixTraces.push({
+        x: Array(activeIdx.length).fill(xIdx),
+        y: activeIdx,
+        mode: "markers",
+        marker: { color: "#1f2937", size: 14 },
+        showlegend: false,
+        xaxis: "x",
+        yaxis: "y2",
+        hoverinfo: "none",
+      });
+    });
+
+    const layout = {
+      grid: { rows: 2, columns: 1, pattern: "independent" },
+      margin: { t: 40, l: 100, r: 20, b: 40 },
+      showlegend: false,
+      xaxis: { visible: false, domain: [0, 1] },
+      yaxis: {
+        title: "Intersection Size",
+        domain: [0.4, 1],
+        fixedrange: true,
+      },
+      yaxis2: {
+        title: "Sets",
+        domain: [0, 0.35],
+        tickvals: [0, 1, 2, 3],
+        ticktext: setNames,
+        range: [-0.5, 3.5],
+        autorange: "reversed",
+        fixedrange: true,
+      },
+      plot_bgcolor: "rgba(0,0,0,0)",
+      paper_bgcolor: "rgba(0,0,0,0)",
+      hovermode: "closest",
+    };
+
+    return { data: [traceBar, ...matrixTraces], layout };
+  }
+
+  function buildSummaryVennSpec(stats) {
+    const s = stats || { topOnly: 0, leadOnly: 0, both: 0 };
+    const total = s.topOnly + s.leadOnly + s.both;
+    const getPct = (v) => (total > 0 ? `${((v / total) * 100).toFixed(1)}%` : "0%");
+
+    const traces = [
+      {
+        x: [0, 1],
+        y: [0, 1],
+        mode: "markers",
+        marker: { opacity: 0 },
+        hoverinfo: "none",
+        showlegend: false,
+      },
+    ];
+
+    const layout = {
+      xaxis: { visible: false, range: [0, 1], fixedrange: true },
+      yaxis: { visible: false, range: [0, 1], fixedrange: true },
+      margin: { t: 30, l: 10, r: 10, b: 10 },
+      plot_bgcolor: "rgba(0,0,0,0)",
+      paper_bgcolor: "rgba(0,0,0,0)",
+      shapes: [
+        {
+          type: "circle",
+          xref: "x",
+          yref: "y",
+          x0: 0.15,
+          y0: 0.1,
+          x1: 0.65,
+          y1: 0.85,
+          fillcolor: "rgba(147, 51, 234, 0.3)",
+          line: { color: "#9333ea", width: 2 },
+        },
+        {
+          type: "circle",
+          xref: "x",
+          yref: "y",
+          x0: 0.35,
+          y0: 0.1,
+          x1: 0.85,
+          y1: 0.85,
+          fillcolor: "rgba(56, 189, 248, 0.3)",
+          line: { color: "#38bdf8", width: 2 },
+        },
+      ],
+      annotations: [
+        { x: 0.25, y: 0.95, text: "<b>Top</b>", showarrow: false, font: { size: 16, color: "#7e22ce" } },
+        { x: 0.75, y: 0.95, text: "<b>Lead</b>", showarrow: false, font: { size: 16, color: "#38bdf8" } },
+        { x: 0.25, y: 0.48, text: `<b>${s.topOnly}</b><br>(${getPct(s.topOnly)})`, showarrow: false, font: { size: 14 } },
+        { x: 0.75, y: 0.48, text: `<b>${s.leadOnly}</b><br>(${getPct(s.leadOnly)})`, showarrow: false, font: { size: 14, color: "#38bdf8" } },
+        { x: 0.5, y: 0.48, text: `<b>${s.both}</b><br>(${getPct(s.both)})`, showarrow: false, font: { size: 14, color: "#111827" } },
+      ],
+    };
+
+    return { data: traces, layout, empty: total === 0 };
+  }
+
+  function buildSummaryProbDistSpec(rows) {
+    const buildTrace = (roleFilter, name, color) => {
+      const filtered = (rows || []).filter((d) => d.role === roleFilter);
+      if (filtered.length === 0) return null;
+      return {
+        y: filtered.map((d) => d.rawProb),
+        text: filtered.map(
+          (d) =>
+            `<b>${d.name}</b><br>Role: ${d.role}<br>Clump: ${d.clump}<br>Prob: ${d.prob}<br>Sig: ${d.significance}`,
+        ),
+        type: "box",
+        name,
+        marker: { color },
+        boxpoints: "all",
+        jitter: 0.3,
+        pointpos: -1.8,
+        hoverinfo: "y+text",
+      };
+    };
+
+    const traces = [
+      buildTrace("🏆 Top", "Top Only", "#9333ea"),
+      buildTrace("⭐ Lead", "Lead Only", "#38bdf8"),
+      buildTrace("🏆 Top & ⭐ Lead", "Both", "#111827"),
+    ].filter((t) => t !== null);
+
+    const layout = {
+      margin: { t: 20, l: 40, r: 20, b: 30 },
+      yaxis: { title: "Probability", range: [-0.05, 1.05] },
+      showlegend: false,
+      plot_bgcolor: "rgba(0,0,0,0)",
+      paper_bgcolor: "rgba(0,0,0,0)",
+    };
+
+    return { data: traces, layout, empty: traces.length === 0 };
+  }
+
+  function buildSummaryDistanceSpec(distances) {
+    if (!distances || distances.length === 0) {
+      return {
+        data: [],
+        layout: {
+          margin: { t: 20, l: 60, r: 20, b: 30 },
+          plot_bgcolor: "rgba(0,0,0,0)",
+          paper_bgcolor: "rgba(0,0,0,0)",
+        },
+        empty: true,
+      };
+    }
+
+    const yVals = distances.map((d) => d.dist);
+    const textVals = distances.map(
+      (d) =>
+        `<b>Variant:</b> ${d.variant}<br><b>Gene:</b> ${d.gene}<br><b>Distance:</b> ${d.dist.toLocaleString()} BP`,
+    );
+
+    const traces = [
+      {
+        y: yVals,
+        text: textVals,
+        type: "box",
+        name: "Nearest Gene",
+        marker: { color: "#059669" },
+        boxpoints: "all",
+        jitter: 0.3,
+        pointpos: -1.8,
+        hoverinfo: "y+text",
+      },
+    ];
+
+    const layout = {
+      margin: { t: 20, l: 60, r: 20, b: 30 },
+      yaxis: { title: "Distance (BP)", autorange: true },
+      showlegend: false,
+      plot_bgcolor: "rgba(0,0,0,0)",
+      paper_bgcolor: "rgba(0,0,0,0)",
+    };
+
+    return { data: traces, layout };
+  }
+
+  function buildSummaryLeadDistanceSpec(leadDistances) {
+    if (!leadDistances || leadDistances.length === 0) {
+      return {
+        data: [],
+        layout: {
+          margin: { t: 20, l: 60, r: 20, b: 30 },
+          plot_bgcolor: "rgba(0,0,0,0)",
+          paper_bgcolor: "rgba(0,0,0,0)",
+        },
+        empty: true,
+      };
+    }
+
+    const yVals = leadDistances.map((d) => d.dist);
+    const textVals = leadDistances.map(
+      (d) =>
+        `<b>Chr:</b> ${d.chr}<br><b>Variant 1:</b> ${d.v1}<br><b>Variant 2:</b> ${d.v2}<br><b>Distance:</b> ${d.dist.toLocaleString()} BP`,
+    );
+
+    const traces = [
+      {
+        y: yVals,
+        text: textVals,
+        type: "box",
+        name: "Lead-to-Lead",
+        marker: { color: "#eab308" },
+        boxpoints: "all",
+        jitter: 0.3,
+        pointpos: -1.8,
+        hoverinfo: "y+text",
+      },
+    ];
+
+    const layout = {
+      margin: { t: 20, l: 60, r: 20, b: 30 },
+      yaxis: { title: "Distance (BP)", autorange: true },
+      showlegend: false,
+      plot_bgcolor: "rgba(0,0,0,0)",
+      paper_bgcolor: "rgba(0,0,0,0)",
+    };
+
+    return { data: traces, layout };
+  }
+
   return {
     buildGenesScatterSpec,
     buildVariantsScatterSpec,
     buildLogIterHistogramSpec,
     buildLogPreprocessBarSpec,
     buildLogPreprocessByStepSpec,
+    buildSummaryUpsetSpec,
+    buildSummaryVennSpec,
+    buildSummaryProbDistSpec,
+    buildSummaryDistanceSpec,
+    buildSummaryLeadDistanceSpec,
   };
 }

--- a/frontend/composables/useFalconPlots.js
+++ b/frontend/composables/useFalconPlots.js
@@ -135,13 +135,22 @@ export function useFalconPlots(store) {
       });
     }
 
+    // The CLUMP ID legend is only useful while it stays compact. Once the
+    // dataset has more clumps than will visually fit alongside the plot
+    // (~25), Plotly's external legend column eats most of the horizontal
+    // space and makes the scatter unreadable. Hide it past that threshold;
+    // the per-trace name is still in hover text + the data table.
+    const LEGEND_TRACE_LIMIT = 25;
+    const showLegend = traces.length <= LEGEND_TRACE_LIMIT;
     const layout = {
       xaxis: { title: "PROBABILITY" },
       yaxis: { title: "Negative Log10(P-Value)" },
       hovermode: "closest",
-      margin: { t: 30, l: 60, r: 20, b: 50 },
-      showlegend: true,
-      legend: {
+      margin: { t: 30, l: 60, r: showLegend ? 20 : 30, b: 50 },
+      showlegend: showLegend,
+    };
+    if (showLegend) {
+      layout.legend = {
         title: { text: "CLUMP ID" },
         x: 1.02,
         y: 1,
@@ -150,8 +159,8 @@ export function useFalconPlots(store) {
         bgcolor: "rgba(255,255,255,0.8)",
         bordercolor: "#d1d5db",
         borderwidth: 1,
-      },
-    };
+      };
+    }
     return { data: traces, layout };
   }
 

--- a/frontend/composables/useFalconSummary.js
+++ b/frontend/composables/useFalconSummary.js
@@ -4,6 +4,11 @@
 // variants. Preserves original quirk: strict-filter toggle does NOT affect
 // this output (see spec §11).
 import { useFalconFilters } from "~/composables/useFalconFilters";
+import { getColorForClump } from "~/utils/falcon/colorPalette";
+
+const ROLE_TOP = "🏆 Top";
+const ROLE_LEAD = "⭐ Lead";
+const ROLE_BOTH = "🏆 Top & ⭐ Lead";
 
 export function useFalconSummary(store) {
   const { getNegP, normalizedClumpId } = useFalconFilters(store);
@@ -99,5 +104,191 @@ export function useFalconSummary(store) {
     });
   }
 
-  return { computeTopAndLeadSignals, attachClinicalTrials, attachNoveltyFlags };
+  // ---------------------------------------------------------------------
+  // Plot-shaped rows (matches SummaryModule.processDataset in original
+  // PEGS app.js:749-845). Each row has
+  //   { clump, color, name, prob, rawProb, rawSig, significance, role,
+  //     hasClinicalTrials, clinicalTrials, isNovel }
+  // plus `stats = { topOnly, leadOnly, both }` returned alongside.
+  // ---------------------------------------------------------------------
+  function computeSummaryRowsForPlots(name /* 'genes' | 'variants' */) {
+    const dataset = store.datasets[name];
+    if (!dataset || !dataset.isLoaded) {
+      return { results: [], stats: { topOnly: 0, leadOnly: 0, both: 0 } };
+    }
+
+    const data = dataset.data;
+    const isVariants = name === "variants";
+    const keyName = isVariants ? "VARIANT" : "GENE";
+    const keyLead = isVariants ? "LEAD_SNP" : "NEAREST_TO_LEAD";
+    const keyNegP = isVariants ? "P_VALUE" : "NEG_LOG_P";
+
+    // Pass 1: STRICT top-per-clump (prob >= 0.05 AND negP >= 1).
+    const topPerClump = new Map();
+    data.forEach((row, idx) => {
+      const prob = parseFloat(row["PROBABILITY"]);
+      const negP = getNegP(row, isVariants);
+      if (isNaN(prob) || prob < 0.05) return;
+      if (isNaN(negP) || negP < 1) return;
+      const clumpId = row["CLUMP"] ? row["CLUMP"].toString().trim() : "Unassigned";
+      if (!topPerClump.has(clumpId) || prob > topPerClump.get(clumpId).prob) {
+        topPerClump.set(clumpId, { index: idx, prob });
+      }
+    });
+
+    // Pass 2: emit flat rows under the user's global filter.
+    const results = [];
+    const stats = { topOnly: 0, leadOnly: 0, both: 0 };
+
+    data.forEach((row, idx) => {
+      const prob = parseFloat(row["PROBABILITY"]);
+      const negP = getNegP(row, isVariants);
+      if (store.globalFilter.active) {
+        if (isNaN(prob) || prob < store.globalFilter.minProb) return;
+        if (isNaN(negP) || negP < store.globalFilter.minNegP) return;
+      }
+
+      const clumpId = row["CLUMP"] ? row["CLUMP"].toString().trim() : "Unassigned";
+      const isTop = topPerClump.get(clumpId)?.index === idx;
+      const leadRaw = String(row[keyLead] || "").toLowerCase().trim();
+      const isLead = leadRaw === "true" || leadRaw === "1" || leadRaw === "yes";
+      if (!isTop && !isLead) return;
+
+      let role;
+      if (isTop && isLead) {
+        role = ROLE_BOTH;
+        stats.both++;
+      } else if (isTop) {
+        role = ROLE_TOP;
+        stats.topOnly++;
+      } else {
+        role = ROLE_LEAD;
+        stats.leadOnly++;
+      }
+
+      const rawSig = parseFloat(row[keyNegP]);
+      const formattedSig = isVariants
+        ? rawSig === 0
+          ? "0.0"
+          : isNaN(rawSig)
+            ? ""
+            : rawSig.toExponential(2)
+        : isNaN(rawSig)
+          ? ""
+          : rawSig.toFixed(2);
+
+      const itemName = row[keyName] || row["RSID"] || row["SNP"] || "Unknown";
+      const trials = !isVariants && store.clinicalTrials.isLoaded
+        ? store.clinicalTrials.byGene[itemName?.toUpperCase?.()] || []
+        : [];
+
+      results.push({
+        clump: clumpId,
+        color: getColorForClump(store.caches.clumpColor, clumpId),
+        name: itemName,
+        prob: prob.toFixed(4),
+        rawProb: prob,
+        rawSig,
+        significance: formattedSig,
+        role,
+        hasClinicalTrials: trials.length > 0,
+        clinicalTrials: trials,
+        isNovel: null,
+      });
+    });
+
+    return { results, stats };
+  }
+
+  function computeOverlapStats(name) {
+    return computeSummaryRowsForPlots(name).stats;
+  }
+
+  // ---------------------------------------------------------------------
+  // Replicates the PEGS "Distance Data Extraction" block (app.js:853-921).
+  // Returns { distances, leadDistances }:
+  //   distances = [{ dist, gene, variant }]
+  //   leadDistances = [{ dist, chr, v1, v2 }]
+  // ---------------------------------------------------------------------
+  function computeDistances() {
+    const distances = [];
+    const leadDistances = [];
+    if (!store.datasets.genes.isLoaded || !store.datasets.variants.isLoaded) {
+      return { distances, leadDistances };
+    }
+
+    const rawGenes = store.datasets.genes.data;
+    const rawVariants = store.datasets.variants.data;
+
+    const leadGenes = new Set();
+    rawGenes.forEach((row) => {
+      const leadVal = String(row["NEAREST_TO_LEAD"] || "").toLowerCase().trim();
+      if (leadVal === "true" || leadVal === "1" || leadVal === "yes") {
+        const gName = row["GENE"] || row["ID"];
+        if (gName) leadGenes.add(gName);
+      }
+    });
+
+    const leadsByChr = {};
+
+    rawVariants.forEach((row) => {
+      const leadRaw = String(row["LEAD_SNP"] || "").toLowerCase().trim();
+      const isLead = leadRaw === "true" || leadRaw === "1" || leadRaw === "yes";
+      if (!isLead) return;
+
+      // Distance to nearest gene.
+      const nearestGene = row["NEAREST_GENE"];
+      if (nearestGene && leadGenes.has(nearestGene)) {
+        const distStr = row["NEAREST_DISTANCE"];
+        if (distStr !== undefined && distStr !== "") {
+          const dist = parseFloat(distStr);
+          if (!isNaN(dist)) {
+            distances.push({
+              dist: Math.abs(dist),
+              gene: nearestGene,
+              variant: row["VARIANT"] || row["RSID"] || row["SNP"] || "Unknown",
+            });
+          }
+        }
+      }
+
+      // Collect leads grouped by chromosome.
+      const chr = row["CHR"] != null ? String(row["CHR"]).trim() : "";
+      const posStr = row["POS"];
+      if (chr && posStr !== undefined && posStr !== "") {
+        const pos = parseInt(posStr, 10);
+        if (!isNaN(pos)) {
+          if (!leadsByChr[chr]) leadsByChr[chr] = [];
+          leadsByChr[chr].push({
+            pos,
+            variant: row["VARIANT"] || row["RSID"] || row["SNP"] || "Unknown",
+          });
+        }
+      }
+    });
+
+    Object.keys(leadsByChr).forEach((chr) => {
+      const leads = leadsByChr[chr].sort((a, b) => a.pos - b.pos);
+      for (let i = 1; i < leads.length; i++) {
+        const dist = leads[i].pos - leads[i - 1].pos;
+        leadDistances.push({
+          dist,
+          chr,
+          v1: leads[i - 1].variant,
+          v2: leads[i].variant,
+        });
+      }
+    });
+
+    return { distances, leadDistances };
+  }
+
+  return {
+    computeTopAndLeadSignals,
+    attachClinicalTrials,
+    attachNoveltyFlags,
+    computeSummaryRowsForPlots,
+    computeOverlapStats,
+    computeDistances,
+  };
 }

--- a/frontend/composables/useGeneTraitFetcher.js
+++ b/frontend/composables/useGeneTraitFetcher.js
@@ -12,52 +12,131 @@ const TRAIT_URL_BASE =
   "https://api.codetabs.com/v1/proxy?quest=" +
   encodeURIComponent("https://hugeampkpncms.org/rest/egls?gene=");
 
+// Module-scope cache so calling useGeneTraitFetcher() again reuses the
+// loaded catalog (matches the original's GeneTraitFetcher singleton).
+const catalogByPageId = {};
+let catalogReady = false;
+let catalogPromise = null;
+
 export function useGeneTraitFetcher(store) {
+
   async function fetchCatalog(signal) {
-    const res = await fetch(CATALOG_URL, { signal });
-    if (!res.ok) throw new Error(`catalog fetch: HTTP ${res.status}`);
-    const json = await res.json();
-    const csvText = json.field_data_points;
-    if (typeof csvText !== "string") throw new Error("catalog: unexpected shape");
-    return new Promise((resolve, reject) => {
-      Papa.parse(csvText, {
-        header: true,
-        skipEmptyLines: true,
-        complete: (r) => {
-          r.data.forEach((row) => {
-            const g = (row.Gene || "").toUpperCase().trim();
-            if (!g) return;
-            if (!store.caches.traitLookup[g]) store.caches.traitLookup[g] = [];
-            store.caches.traitLookup[g].push(row);
-          });
-          resolve();
-        },
-        error: (err) => reject(err),
+    if (catalogReady) return;
+    if (catalogPromise) return catalogPromise;
+
+    catalogPromise = (async () => {
+      const res = await fetch(CATALOG_URL, { signal });
+      if (!res.ok) throw new Error(`catalog fetch: HTTP ${res.status}`);
+      const json = await res.json();
+      // The HuGEAMP endpoint returns an array; PEGS app.js:1776 uses json[0].
+      // Be permissive in case the proxy ever flattens to a bare object.
+      const root = Array.isArray(json) ? json[0] : json;
+      const csvText = root && root.field_data_points;
+      if (typeof csvText !== "string") {
+        throw new Error("catalog: unexpected shape (no field_data_points)");
+      }
+      await new Promise((resolve, reject) => {
+        Papa.parse(csvText, {
+          header: true,
+          skipEmptyLines: true,
+          complete: (r) => {
+            r.data.forEach((row) => {
+              const pageId = row["Page ID"];
+              if (pageId) catalogByPageId[pageId] = row;
+            });
+            resolve();
+          },
+          error: (err) => reject(err),
+        });
       });
+      catalogReady = true;
+    })().finally(() => {
+      catalogPromise = null;
     });
+    return catalogPromise;
   }
 
   async function fetchTraits(geneNames, signal) {
+    // Make sure the master catalog is loaded once before any per-gene fetch.
+    if (!catalogReady) {
+      try {
+        await fetchCatalog(signal);
+      } catch (err) {
+        if (err.name === "AbortError") throw err;
+        // Without a catalog we can't translate page IDs to traits, so
+        // mark every requested gene as having no traits and bail out.
+        console.error("[useGeneTraitFetcher] catalog load failed:", err);
+        geneNames.forEach((g) => {
+          const key = (g || "").toUpperCase().trim();
+          if (key && !store.caches.traitLookup[key]) {
+            store.caches.traitLookup[key] = [];
+          }
+        });
+        return;
+      }
+    }
+
     const unique = Array.from(
       new Set(geneNames.map((g) => g.toUpperCase().trim()).filter(Boolean)),
     );
     const todo = unique.filter((g) => !store.caches.traitLookup[g]);
-    await Promise.all(
-      todo.map(async (g) => {
-        try {
-          const res = await fetch(TRAIT_URL_BASE + encodeURIComponent(g), { signal });
-          if (!res.ok) {
-            store.caches.traitLookup[g] = [];
-            return;
-          }
-          const json = await res.json();
-          store.caches.traitLookup[g] = Array.isArray(json) ? json : json?.data || [];
-        } catch (err) {
-          if (err.name === "AbortError") throw err;
+
+    // Throttled worker pool — Chrome rejects unbounded parallel fetches with
+    // ERR_INSUFFICIENT_RESOURCES once you push past a few hundred. The
+    // codetabs proxy is also rate-limited; CONCURRENCY=8 is conservative.
+    const CONCURRENCY = 8;
+    let i = 0;
+
+    async function fetchOne(g) {
+      try {
+        const res = await fetch(TRAIT_URL_BASE + encodeURIComponent(g), {
+          signal,
+        });
+        if (!res.ok) {
           store.caches.traitLookup[g] = [];
+          return;
         }
-      }),
-    );
+        const json = await res.json();
+        // The egls endpoint returns an array of { field_page_id, ... }.
+        // For each, look up the catalog row to materialise a trait record.
+        const items = Array.isArray(json) ? json : json?.data || [];
+        const traits = [];
+        items.forEach((item) => {
+          const pageId = item && (item.field_page_id || item["Page ID"]);
+          const rowData = pageId ? catalogByPageId[pageId] : null;
+          if (rowData) {
+            traits.push({
+              page_id: pageId,
+              trait: rowData["Trait"] || "N/A",
+              pmid: rowData["PMID"] || "N/A",
+              citation: rowData["Citation"] || "N/A",
+              authors: rowData["short_name"] || "N/A",
+            });
+          }
+        });
+        store.caches.traitLookup[g] = traits;
+      } catch (err) {
+        if (err.name === "AbortError") throw err;
+        // Don't log every failure; log summary at end. Treat as no-traits so
+        // the user still sees deterministic behaviour.
+        store.caches.traitLookup[g] = [];
+      }
+    }
+
+    async function worker() {
+      while (i < todo.length) {
+        if (signal && signal.aborted) {
+          const e = new Error("Aborted");
+          e.name = "AbortError";
+          throw e;
+        }
+        const g = todo[i++];
+        await fetchOne(g);
+      }
+    }
+
+    const workers = Array.from({ length: Math.min(CONCURRENCY, todo.length) }, () => worker());
+    await Promise.all(workers);
   }
 
   return { fetchCatalog, fetchTraits };

--- a/frontend/composables/usePlotly.js
+++ b/frontend/composables/usePlotly.js
@@ -16,6 +16,17 @@ export function usePlotly() {
     const Plotly = await loadPlotly();
     const config = { responsive: true, displaylogo: false, ...(spec.config || {}) };
     await Plotly.newPlot(el, spec.data, spec.layout, config);
+    // PrimeVue Tabs lazy-mounts panels: when our plot first paints, the
+    // host is display:none, so Plotly latches a 0-width canvas. After the
+    // next animation frame the panel has its real dimensions; nudge Plotly
+    // to recompute. Fixes "Genes Plot / Variants Plot squished to the left".
+    requestAnimationFrame(() => {
+      try {
+        if (el && el.offsetParent !== null) Plotly.Plots.resize(el);
+      } catch {
+        // best-effort resize; safe to swallow if Plotly disposed the element.
+      }
+    });
     return el;
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #31. The original merge of PR #31 happened before the bug-fix and Summary-plot commits were pushed to \`falcon-variant-b\` — only the foundation work landed in \`main\`. This PR brings in the missing commits.

**Commits on this branch not yet in \`main\`:**

```
efb202b feat(falcon-b): restore Executive Summary plots
ebd839d fix(falcon-b): restore per-section search and role filter on Executive Summary
019a14a fix(falcon-b): repair LD Matrix layout and restore plotly_click inspector
c494a1c fix(falcon-b): add Pre-process Times section and reformat total time
ea1977e fix(falcon-b): add per-step pre-process spec builder to useFalconPlots
8262bf9 fix(falcon-a): repair novelty fetcher (catalog shape + parallel limit)  ← cherry-pick
47f9c8f fix(falcon-a): cap scatter legend when clump count exceeds threshold     ← cherry-pick
bab7f10 fix(falcon-a): resize scatter plots after lazy tab mount                  ← cherry-pick
```

The three cherry-picked commits also exist on the companion variant-a follow-up PR (#33). After #33 merges first, those three commits will already be in \`main\` and this merge will resolve cleanly.

## What gets fixed

Same bugs as #33 (mirrored to Variant B's PrimeVue-shell + custom-CSS aesthetic):

- **Tab Layout (Genes/Variants squished)** — scatter legend cap (cherry-pick).
- **LD Matrix slider overlap** — fixed using Variant B's native-input toolbar layout.
- **Executive Summary filters missing** — per-section search/role/paginator using \`.search-input\` / \`.page-btn\` / native \`<select>\`.
- **Novelty broken** — fixed in \`useGeneTraitFetcher\` (cherry-pick).
- **FALCON Zoom clipboard lost** — \`plotly_click\` → inspector wired.
- **Execution Time formatting** — total time now \"1h 42m 29.27s (6149.27s)\".
- **Pre-process Times section missing** — added in Variant B's plain-card style.
- **All Executive Summary plots missing** — six plots restored using Variant B's plain-card aesthetic.

## Test plan

- [ ] Visit \`/falcon-b\`; load fixture (e.g. T2D)
- [ ] Executive Summary: 6 plots render at top; per-section filters work
- [ ] Genes/Variants Plot: scatters render full-width
- [ ] Data Table: native HTML table with sticky header + Prev/Next paginator
- [ ] FALCON Zoom: Run Analysis renders plot; click a point opens inspector
- [ ] Execution Time: time format correct; Pre-process Steps card present
- [ ] Novelty toggle works

## Merge order

Merge #33 (variant-a) first, then this. Cherry-picks will collapse cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)