### PR TITLE
fix(ci): make falcon-cli-e2e bats job reliable (Linux-only, apt install)

### DIFF
--- a/.github/workflows/falcon-cli-e2e.yml
+++ b/.github/workflows/falcon-cli-e2e.yml
@@ -7,23 +7,25 @@ on:
       - 'tests/run-sh/**'
       - 'job_server/api.py'
       - 'job_server/falcon_tokens.py'
+      # Trigger on changes to this workflow too, so CI fixes are validated
+      # without needing an unrelated code change (mirrors api-ci.yml).
+      - '.github/workflows/falcon-cli-e2e.yml'
 
 jobs:
   bats:
     name: bats run.sh tests
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    # Linux-only: all run.sh tests pass on Linux (verified locally). The GitHub
+    # macOS runner lacks Docker and the harness hangs there (~16 min then fails),
+    # unreproducible on Linux; low value given run.sh is slated for deprecation
+    # (FALCON moving to AWS Batch). Re-add a macos-latest leg if that changes.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - name: Install bats-core (macOS)
-        if: runner.os == 'macOS'
-        run: brew install bats-core
-      - name: Install bats-core (Ubuntu)
-        if: runner.os == 'Linux'
-        run: npm install -g bats
+      # apt is reliable on the runner; `npm install -g bats` was failing in the
+      # runner's global-npm environment before the tests could run.
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
       - name: Run bats
         run: bats tests/run-sh/
 


### PR DESCRIPTION
## Problem

The `FALCON CLI E2E` workflow's `bats run.sh tests` job has never passed. Its first-ever run was on PR #48 (which merely tripped the trigger via `job_server/api.py`), and both matrix legs failed:

- **ubuntu-latest** — failed at the *install step* (`npm install -g bats`) in the runner's global-npm environment, before any test ran.
- **macos-latest** — ran ~16 minutes then failed. GitHub macOS runners lack Docker and the `run.sh` harness hangs there.

Investigation: all **26 `tests/run-sh/` tests pass on Linux** (verified locally with both npm- and apt-installed `bats`), so the tests are sound — the failures are the install step (ubuntu) and a macOS-runner-specific hang, not the tests.

## Fix

- **Install `bats` via `apt`** instead of `npm install -g` (reliable on the runner).
- **Run Linux-only** — drops the `macos-latest` leg. Linux retains full coverage (all 26 tests). The macOS hang is unreproducible without a Mac and low value given `run.sh` is slated for deprecation (FALCON moving to AWS Batch). Re-add a `macos-latest` leg if that changes and the hang is diagnosed/fixed.
- **`timeout-minutes: 10`** guard so a future hang fails fast instead of burning ~16 min of runner time.
- **Self-trigger** on `.github/workflows/falcon-cli-e2e.yml` (mirrors `api-ci.yml`) so CI-config changes like this one are actually validated — which is why this PR's own run exercises the fix.

## Verification
- Local: `bats tests/run-sh/` → 26/26 pass (npm bats 1.13.0 and apt bats 1.2.1).
- CI: this PR self-triggers the workflow; expect `bats` green + `pytest` green (the pytest `:3308` fix already landed on `main` via #48).

Separate from the variant-sifter feature. Addresses the falcon-CLI failures documented in #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
